### PR TITLE
Remove Slack notification for Heroku deployment

### DIFF
--- a/.github/workflows/heroku-deployment.yml
+++ b/.github/workflows/heroku-deployment.yml
@@ -16,18 +16,3 @@ jobs:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
-
-  slackNotification:
-    name: Slack Notification
-    needs: deploy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_USERNAME: deploy_bot
-          SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_TITLE: New deployment
-          SLACK_ICON_EMOJI: ":ship:"


### PR DESCRIPTION
This is causing a lot of noise in the Slack channel, so I think for now we may as well remove it.

<!-- Do you need to update the changelog? -->

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
