### PR TITLE
(51) Use WMS services to compose map with layers

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -1,15 +1,32 @@
 document.addEventListener("turbolinks:load", function () {
-  console.log("Turbolinks loaded map.js file");
   const mapEle = document.querySelector("#map");
 
   if (mapEle) {
-    console.log("map placeholder element found. Will draw map...");
-    const map = L.map("map").setView([51.505, -0.09], 13);
+    const bigBenLatLng = [51.510357, -0.116773];
+    const map = L.map("map").setView(bigBenLatLng, 10);
 
-    L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
-      maxZoom: 19,
-      attribution:
-        '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-    }).addTo(map);
+    const cercOptions = {
+      layers: "london:Total",
+      time: "2024-09-25",
+      format: "image/png",
+      transparency: true, // term used by CERC
+      styles: "daqiTotal",
+      // styles: "daqiTotal_linear"
+      //   we heard: "This can provide a more detailed map, at the expense of
+      //   less clearly defined bands."
+    };
+    const osmOptions = {
+      layers: "OSM-Overlay-WMS",
+      format: "image/png",
+      transparent: true, // standard term (?) used by Leaflet and OSM
+    };
+
+    // compose the map using our WMS layers
+    L.tileLayer
+      .wms("https://airtext.info/geoserver/wms?", cercOptions)
+      .addTo(map);
+    L.tileLayer
+      .wms("https://ows.mundialis.de/services/service?", osmOptions)
+      .addTo(map);
   }
 });


### PR DESCRIPTION
We obtain map tiles from two Web Map Services:

### 1. OpenStreetMap: OSM Overlay WMS - by terrestris 
http://ows.mundialis.de/services/service 
Layer name: OSM-Overlay-WMS

### 2.  GeoServer Web Map Service for CERC 
https://airtext.info/geoserver/wms 
Layer name: london:Total

See the article [WMS in Leaflet][] for details.

[WMS in Leaflet]:
https://leafletjs.com/examples/wms/wms.html

### Screenshot

<img width="500" alt="two_layers" src="https://github.com/user-attachments/assets/9d93d0a3-974c-42ad-9473-08892cada686">

### Composing the WMS layers in QGIS

<img width="1431" alt="two_wms_layers_composed" src="https://github.com/user-attachments/assets/cd7e920d-9026-4587-ad17-95d09cca486a">

