### PR TITLE
Toggle air quality styling

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "proseWrap": "always"
+  "proseWrap": "always",
+  "trailingComma": "es5"
 }


### PR DESCRIPTION
So that we can understand the difference between the original "discrete" colour styling and the new option for "linear" colours, we now define two "base layers":

1. AirTEXT air quality with original "discrete" styling
2. AirTEXT air quality with new "linear"  styling

And an "overlay layer"  for the OpenStreetMap tiles.

We can now:

- toggle between the two styles: "discrete" and "linear"
- switch the OSM layer on and off

<img width="1182" alt="toggling_and_switching_layers" src="https://github.com/user-attachments/assets/16499291-98fa-4926-9946-1454c7de1848">

