### PR TITLE
Implement static forecast

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "sass-rails", "~> 6.0"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "terser"
+gem "govuk-components"
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,13 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    govuk-components (5.6.1)
+      html-attributes-utils (~> 1.0.0, >= 1.0.0)
+      pagy (>= 6, < 10)
+      view_component (>= 3.9, < 3.15)
     high_voltage (4.0.0)
+    html-attributes-utils (1.0.2)
+      activesupport (>= 6.1.4.4)
     htmlbeautifier (1.4.3)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
@@ -205,6 +211,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    pagy (9.0.9)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -395,6 +402,10 @@ GEM
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
     useragent (0.16.10)
+    view_component (3.14.0)
+      activesupport (>= 5.2.0, < 8.0)
+      concurrent-ruby (~> 1.0)
+      method_source (~> 1.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -430,6 +441,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  govuk-components
   high_voltage
   htmlbeautifier
   jbuilder (~> 2.11)

--- a/app/assets/stylesheets/1st_load_framework.css.scss
+++ b/app/assets/stylesheets/1st_load_framework.css.scss
@@ -53,4 +53,9 @@ section {
 
   margin-top: 20px;
 }
+
+table {
+  caption-side: top;
+}
+
 /* stylelint-enable scss/at-extend-no-missing-placeholder, at-rule-no-unknown */

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -13,3 +13,11 @@
  *= require_tree .
  *= require_self
  */
+
+$govuk-font-url-function: "font-url";
+$govuk-image-url-function: "image-url";
+$govuk-images-path: "govuk-frontend/dist/govuk/assets/images/";
+$govuk-fonts-path: "govuk-frontend/dist/govuk/assets/fonts/";
+$govuk-page-width: 1100px;
+
+@import "govuk-frontend/dist/govuk/all";

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -1,0 +1,6 @@
+class ForecastsController < ApplicationController
+  def index
+    @forecast = JSON.parse(File.read("#{Rails.root}/public/sample-forecast.json"))["zones"][0]
+    @dates = @forecast["forecasts"].map { |forecast| forecast["forecast_date"] }
+  end
+end

--- a/app/views/forecasts/index.html.erb
+++ b/app/views/forecasts/index.html.erb
@@ -1,0 +1,43 @@
+<section class="container">
+  <div class="row">
+    <article class="col">
+      <h1>Forecasts</h1>
+      <%= govuk_table do |table|
+        table.with_caption(size: 'm', text: "Three day forecast for #{@forecast["zone_name"]}")
+
+        table.with_head do |head|
+        head.with_row do |row|
+        row.with_cell(text: '')
+        row.with_cell(text: Date.parse(@dates[0]).to_formatted_s(:short))
+        row.with_cell(text: Date.parse(@dates[1]).to_formatted_s(:short))
+        row.with_cell(text: Date.parse(@dates[2]).to_formatted_s(:short))
+        
+        end; end; table.with_body do |body|
+        body.with_row do |row|
+        row.with_cell(text: 'Air pollution')
+        @forecast["forecasts"].map { | forecast| 
+          row.with_cell(text: forecast["total_status"].capitalize)
+        }
+        end;
+        body.with_row do |row|
+        row.with_cell(text: 'UV')
+        @forecast["forecasts"].map { | forecast| 
+          row.with_cell(text: forecast["uv"])
+        }
+        end;
+        body.with_row do |row|
+          row.with_cell(text: 'Pollen')
+          @forecast["forecasts"].map { | forecast| 
+            row.with_cell(text: forecast["pollen"])
+          }
+        end;
+        body.with_row do |row|
+          row.with_cell(text: 'Temperature')
+          @forecast["forecasts"].map { | forecast| 
+          row.with_cell(text: "#{forecast["temp_min"].round}-#{forecast["temp_max"].round}°C")
+          }
+        end;
+        end; end %>
+    </article>
+  </div>
+</section>

--- a/app/views/visitors/index.html.erb
+++ b/app/views/visitors/index.html.erb
@@ -9,6 +9,8 @@
       <p>Welcome to the rebuild of airTEXT</p>
       <p>
         <%= link_to "View map", map_path, data: { turbo: false } =%>
+        <br/>
+        <%= link_to "View forecasts", forecasts_path, data: { turbo: false } =%>
       </p>
       <p>Please refer to the project's <%= link_to "README", "https://github.com/dxw/air-text", target: :blank %> on Github for further information.
         <h2>Helpful links</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
 
   get "map", to: "map#show"
 
+  get :forecasts, to: "forecasts#index"
+
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that
   # hostname, redirect us to the canonical hostname with the path and query string present
   if ENV["CANONICAL_HOSTNAME"].present?

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "engines": {
     "node": "20.17.0",
     "yarn": "1.22.22"
+  },
+  "dependencies": {
+    "govuk-frontend": "^5.6.0"
   }
 }

--- a/public/sample-forecast.json
+++ b/public/sample-forecast.json
@@ -1,0 +1,70 @@
+{
+  "forecastdate": "01-10-2024 08:50",
+  "timestamp": 1727772642388.884,
+  "zones": [
+    {
+      "forecasts": [
+        {
+          "NO2": 1,
+          "O3": 2,
+          "PM10": 1,
+          "PM2.5": 1,
+          "forecast_date": "2024-10-01",
+          "non_pollution_version": null,
+          "pollen": -999,
+          "pollution_version": 202410010807,
+          "rain_am": 1.31,
+          "rain_pm": 3.01,
+          "temp_max": 14,
+          "temp_min": 10.4,
+          "total": 2,
+          "total_status": "LOW",
+          "uv": 1,
+          "wind_am": 5.3,
+          "wind_pm": 6
+        },
+        {
+          "NO2": 1,
+          "O3": 2,
+          "PM10": 1,
+          "PM2.5": 1,
+          "forecast_date": "2024-10-02",
+          "non_pollution_version": null,
+          "pollen": -999,
+          "pollution_version": 202410010307,
+          "rain_am": 0.31,
+          "rain_pm": 0.47,
+          "temp_max": 16.3,
+          "temp_min": 10,
+          "total": 2,
+          "total_status": "LOW",
+          "uv": 2,
+          "wind_am": 5.1,
+          "wind_pm": 5.8
+        },
+        {
+          "NO2": 1,
+          "O3": 3,
+          "PM10": 1,
+          "PM2.5": 1,
+          "forecast_date": "2024-10-03",
+          "non_pollution_version": null,
+          "pollen": -999,
+          "pollution_version": 202410010307,
+          "rain_am": 0,
+          "rain_pm": 0,
+          "temp_max": 16.9,
+          "temp_min": 7.7,
+          "total": 3,
+          "total_status": "LOW",
+          "uv": 3,
+          "wind_am": 3.9,
+          "wind_pm": 3.2
+        }
+      ],
+      "zone_id": 14,
+      "zone_name": "Haringey",
+      "zone_type": 1
+    }
+  ]
+}

--- a/spec/controllers/forecasts_controller_spec.rb
+++ b/spec/controllers/forecasts_controller_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ForecastsController do
+  describe "GET :index" do
+    it "renders the _index_ template" do
+      get :index
+
+      expect(response).to render_template("index")
+    end
+  end
+end

--- a/spec/features/visitors/view_forecasts_spec.rb
+++ b/spec/features/visitors/view_forecasts_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Feature: Forecasts page
+#   So that I can understand potential health dangers in my area
+#   As a visitor who has chosen a particular zone
+#   I want to see warnings and alerts for both pollutants and non-pollutants for 3 days
+RSpec.feature "Forecasts page" do
+  # Scenario: Visit the home page
+  #   Given I am a visitor
+  #   When I visit the home page
+  #   And I select "View forecasts"
+  #   Then I see the forecasts page
+  #   And I see local air quality information
+  scenario "visit the forecasts page" do
+    visit root_path
+    when_i_select_view_forecasts
+    then_i_see_the_forecasts_page
+    and_i_see_local_air_quality_information
+  end
+
+  def when_i_select_view_forecasts
+    click_link("View forecasts")
+  end
+
+  def then_i_see_the_forecasts_page
+    expect(page).to have_content("Forecasts")
+  end
+
+  def and_i_see_local_air_quality_information
+    expect(page).to have_content("Three day forecast for Haringey")
+    within first(".govuk-table__row") do
+      page.all("td").each_with_index do |td, index|
+        if index == 0
+          expect(td).to have_content("Air pollution")
+        else
+          expect(td).to have_content("Low")
+        end
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,6 +631,11 @@ globjoin@^0.1.4:
   resolved "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz"
   integrity sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==
 
+govuk-frontend@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.6.0.tgz#8c0975f0d825ec7192bcfe64e3e97ef3dfa7dea1"
+  integrity sha512-yNA4bL7i7mNrg36wPNZ3RctHo9mjl82Phs8MWs1lwovxJuQ4ogEo/XWn2uB1HxkXNqgMlW4wnd0iiKgRMfxYfw==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"


### PR DESCRIPTION
## Changes in this PR

Adds a basic forecast view, with data pulled from a static json file, and the table rendered using the GOV.UK component.

## Screenshots of UI changes

![Screenshot 2024-10-01 at 11 34 15](https://github.com/user-attachments/assets/4bc21653-e46e-4ca7-865a-15363a225ceb)

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
