### PR TITLE
(63) Show guidance on 3 day matrix of forecasts

### DIFF
--- a/app/lib/forecast_factory.rb
+++ b/app/lib/forecast_factory.rb
@@ -24,8 +24,8 @@ class ForecastFactory
           particulate_matter_10: forecast.fetch("PM10"),
           particulate_matter_2_5: forecast.fetch("PM2.5"),
           ozone: forecast.fetch("O3"),
-          overall_score: forecast.fetch("total"),
-          overall_label: forecast.fetch("total_status")
+          value: forecast.fetch("total"),
+          label: forecast.fetch("total_status")
         ),
 
         uv: UvPrediction.new(forecast.fetch("uv")),

--- a/app/lib/forecast_factory.rb
+++ b/app/lib/forecast_factory.rb
@@ -29,7 +29,7 @@ class ForecastFactory
         ),
 
         uv: UvPrediction.new(forecast.fetch("uv")),
-        pollen: forecast.fetch("pollen"),
+        pollen: PollenPrediction.new(forecast.fetch("pollen")),
         temperature: TemperaturePrediction.new(
           min: forecast.fetch("temp_min"),
           max: forecast.fetch("temp_max")

--- a/app/lib/forecast_factory.rb
+++ b/app/lib/forecast_factory.rb
@@ -10,7 +10,7 @@ class ForecastFactory
       .map do |forecast|
       Forecast.new({
         obtained_at: obtained_at,
-        forecast_for: Date.parse(forecast.fetch("forecast_date")),
+        date: Date.parse(forecast.fetch("forecast_date")),
 
         zone: ForecastZone.new(
           id: zone.fetch("zone_id"),

--- a/app/models/air_pollution_prediction.rb
+++ b/app/models/air_pollution_prediction.rb
@@ -4,7 +4,8 @@ class AirPollutionPrediction
     :particulate_matter_10,
     :particulate_matter_2_5,
     :ozone,
-    :overall_score
+    :value,
+    :label
 
   def initialize(
     forecasted_at:,
@@ -12,20 +13,40 @@ class AirPollutionPrediction
     particulate_matter_10:,
     particulate_matter_2_5:,
     ozone:,
-    overall_score:,
-    overall_label:
+    value:,
+    label:
   )
     @forecasted_at = forecasted_at
     @nitrogen_dioxide = nitrogen_dioxide
     @particulate_matter_10 = particulate_matter_10
     @particulate_matter_2_5 = particulate_matter_2_5
     @ozone = ozone
-    @overall_score = overall_score
-    @overall_label = overall_label
+    @value = value
+    @label = label
   end
 
-  def overall_label
-    ActiveSupport::Inflector.upcase_first(@overall_label.downcase)
+  DAQI_LABELS = {
+    low: "Low",
+    moderate: "Moderate",
+    high: "High",
+    very_high: "Very high"
+  }
+
+  def daqi_label
+    DAQI_LABELS.fetch(daqi_level)
+  end
+
+  def daqi_level
+    case @value
+    when 1..3
+      :low
+    when 4..6
+      :moderate
+    when 7..9
+      :high
+    else
+      :very_high
+    end
   end
 
   # :nocov:
@@ -36,8 +57,8 @@ class AirPollutionPrediction
       "@particulate_matter_10=#{particulate_matter_10}",
       "@particulate_matter_2_5=#{particulate_matter_2_5}",
       "@ozone=#{ozone}",
-      "@overall_score=#{overall_score}",
-      "@overall_label=#{@overall_label}"
+      "@value=#{@value}",
+      "@label=#{@label}"
     ]
 
     "#<#{self.class.name} #{attr_values.join(" ")}>"

--- a/app/models/air_pollution_prediction.rb
+++ b/app/models/air_pollution_prediction.rb
@@ -1,4 +1,6 @@
 class AirPollutionPrediction
+  include DaqiProperties
+
   attr_reader :forecasted_at,
     :nitrogen_dioxide,
     :particulate_matter_10,
@@ -23,30 +25,6 @@ class AirPollutionPrediction
     @ozone = ozone
     @value = value
     @label = label
-  end
-
-  DAQI_LABELS = {
-    low: "Low",
-    moderate: "Moderate",
-    high: "High",
-    very_high: "Very high"
-  }
-
-  def daqi_label
-    DAQI_LABELS.fetch(daqi_level)
-  end
-
-  def daqi_level
-    case @value
-    when 1..3
-      :low
-    when 4..6
-      :moderate
-    when 7..9
-      :high
-    else
-      :very_high
-    end
   end
 
   # :nocov:

--- a/app/models/air_quality_alert.rb
+++ b/app/models/air_quality_alert.rb
@@ -13,17 +13,19 @@ class AirQualityAlert
     @forecast.forecast_for
   end
 
-  def level
-    @forecast.air_pollution.overall_label
+  def daqi_level
+    @forecast.air_pollution.daqi_level
   end
 
-  def score
-    @forecast.air_pollution.overall_score
+  def daqi_label
+    @forecast.air_pollution.daqi_label
+  end
+
+  def value
+    @forecast.air_pollution.value
   end
 
   def tag_colour
-    TAG_COLOURS.fetch(
-      ActiveSupport::Inflector.parameterize(level, separator: "_").to_sym
-    )
+    TAG_COLOURS.fetch(daqi_level)
   end
 end

--- a/app/models/air_quality_alert.rb
+++ b/app/models/air_quality_alert.rb
@@ -10,7 +10,7 @@ class AirQualityAlert
   }
 
   def date
-    @forecast.forecast_for
+    @forecast.date
   end
 
   def daqi_level

--- a/app/models/concerns/daqi_properties.rb
+++ b/app/models/concerns/daqi_properties.rb
@@ -1,0 +1,25 @@
+module DaqiProperties
+  DAQI_LABELS = {
+    low: "Low",
+    moderate: "Moderate",
+    high: "High",
+    very_high: "Very high"
+  }
+
+  def daqi_label
+    DAQI_LABELS.fetch(daqi_level)
+  end
+
+  def daqi_level
+    case @value
+    when 1..3
+      :low
+    when 4..6
+      :moderate
+    when 7..9
+      :high
+    else
+      :very_high
+    end
+  end
+end

--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -1,9 +1,9 @@
 class Forecast
-  attr_reader :obtained_at, :forecast_for, :zone, :air_pollution, :uv, :pollen, :temperature
+  attr_reader :obtained_at, :date, :zone, :air_pollution, :uv, :pollen, :temperature
 
   def initialize(attrs)
     @obtained_at = attrs.fetch(:obtained_at)
-    @forecast_for = attrs.fetch(:forecast_for)
+    @date = attrs.fetch(:date)
     @zone = attrs.fetch(:zone)
     @air_pollution = attrs.fetch(:air_pollution)
     @uv = attrs.fetch(:uv)
@@ -25,7 +25,7 @@ class Forecast
   def inspect
     attr_values = [
       "@obtained_at=#{obtained_at}",
-      "@forecast_for=#{forecast_for}",
+      "@date=#{date}",
       "@zone=#{zone.inspect}",
       "@air_pollution=#{air_pollution.inspect}",
       "@uv=#{uv.inspect}",

--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -16,7 +16,7 @@ class Forecast
   end
 
   def air_quality_alert
-    return if air_pollution.overall_label.downcase == "low"
+    return if air_pollution.daqi_level == :low
 
     AirQualityAlert.new(self)
   end

--- a/app/models/pollen_prediction.rb
+++ b/app/models/pollen_prediction.rb
@@ -1,0 +1,41 @@
+class PollenPrediction
+  attr_reader :value
+
+  def initialize(value)
+    @value = value
+  end
+
+  DAQI_LABELS = {
+    low: "Low",
+    moderate: "Moderate",
+    high: "High",
+    very_high: "Very high"
+  }
+
+  def daqi_label
+    DAQI_LABELS.fetch(daqi_level)
+  end
+
+  def daqi_level
+    case @value
+    when 1..3
+      :low
+    when 4..6
+      :moderate
+    when 7..9
+      :high
+    else
+      :very_high
+    end
+  end
+
+  def guidance
+    I18n.t("prediction.guidance.pollen.#{daqi_level}")
+  end
+
+  # :nocov:
+  def inspect
+    "#<#{self.class.name} @value=#{value}>"
+  end
+  # :nocov:
+end

--- a/app/models/pollen_prediction.rb
+++ b/app/models/pollen_prediction.rb
@@ -1,32 +1,10 @@
 class PollenPrediction
+  include DaqiProperties
+
   attr_reader :value
 
   def initialize(value)
     @value = value
-  end
-
-  DAQI_LABELS = {
-    low: "Low",
-    moderate: "Moderate",
-    high: "High",
-    very_high: "Very high"
-  }
-
-  def daqi_label
-    DAQI_LABELS.fetch(daqi_level)
-  end
-
-  def daqi_level
-    case @value
-    when 1..3
-      :low
-    when 4..6
-      :moderate
-    when 7..9
-      :high
-    else
-      :very_high
-    end
   end
 
   def guidance

--- a/app/models/uv_prediction.rb
+++ b/app/models/uv_prediction.rb
@@ -1,27 +1,40 @@
 class UvPrediction
-  attr_reader :level, :label, :guidance
+  attr_reader :value
 
-  def initialize(level)
-    @level = level
-    case level
+  def initialize(value)
+    @value = value
+  end
+
+  DAQI_LABELS = {
+    low: "Low",
+    moderate: "Moderate",
+    high: "High",
+    very_high: "Very high"
+  }
+
+  def daqi_label
+    DAQI_LABELS.fetch(daqi_level)
+  end
+
+  def daqi_level
+    case @value
     when 1..3
-      @label = "Low"
-      @guidance = "No action required. You can safely stay outside."
+      :low
     when 4..6
-      @label = "Moderate"
-      @guidance = "Protection required. Seek shade during midday hours, cover up and wear suncream."
+      :moderate
     when 7..9
-      @label = "High"
-      @guidance = "some high UV guidance"
+      :high
     else
-      @label = "Very high"
-      @guidance = "some very high UV guidance"
+      :very_high
     end
+  end
+
+  def guidance
+    I18n.t("prediction.guidance.uv.#{daqi_level}")
   end
 
   # :nocov:
   def inspect
-    "#<#{self.class.name} @level=#{level} @label=#{label} @guidance=#{guidance}>"
+    "#<#{self.class.name} @value=#{value}>"
   end
-  # :nocov:
 end

--- a/app/models/uv_prediction.rb
+++ b/app/models/uv_prediction.rb
@@ -1,32 +1,10 @@
 class UvPrediction
+  include DaqiProperties
+
   attr_reader :value
 
   def initialize(value)
     @value = value
-  end
-
-  DAQI_LABELS = {
-    low: "Low",
-    moderate: "Moderate",
-    high: "High",
-    very_high: "Very high"
-  }
-
-  def daqi_label
-    DAQI_LABELS.fetch(daqi_level)
-  end
-
-  def daqi_level
-    case @value
-    when 1..3
-      :low
-    when 4..6
-      :moderate
-    when 7..9
-      :high
-    else
-      :very_high
-    end
   end
 
   def guidance

--- a/app/views/forecasts/_air_quality_alerts.html.erb
+++ b/app/views/forecasts/_air_quality_alerts.html.erb
@@ -3,8 +3,8 @@
     <% alerts.each do |alert| %>
       <div class="govuk-grid-column-one-third">
         <% alert_classes =
-          ["alert-level-#{ ActiveSupport::Inflector.parameterize(alert.level)}",
-          "alert-score-#{alert.score}"]
+          ["alert-level-#{ ActiveSupport::Inflector.dasherize(alert.daqi_level.to_s) }",
+          "alert-score-#{alert.value}"]
           .join(" ")
         %>
         <li
@@ -13,28 +13,24 @@
         >
           <div class="heading">
             <%= govuk_tag(
-              text: alert.level.upcase,
+              text: alert.daqi_label.upcase,
               colour: alert.tag_colour.to_s,
               html_attributes: { class: "alert-level" }
               )
             %>
-            (<%= alert.score %> / 10)
+            (<%= alert.value %> / 10)
           </div>
           <p class= "govuk-body body">
             There is a
-            <%= alert.level.upcase %>
+            <%= alert.daqi_label.upcase %>
             air quality alert for
             <%= alert.date.strftime("%d %b %Y") %>
           </p>
           <%= govuk_details(
             summary_text: t(
-              "air_quality_alert.#{ActiveSupport::Inflector.parameterize(
-                alert.level, separator: '_'
-              )}.guidance.title"),
+              "air_quality_alert.#{alert.daqi_level}.guidance.title"),
             text: t(
-              "air_quality_alert.#{ActiveSupport::Inflector.parameterize(
-                alert.level, separator: '_'
-              )}.guidance.detail_html"),
+              "air_quality_alert.#{alert.daqi_level}.guidance.detail_html"),
             html_attributes: {class: "guidance"}
           ) %>
         </li>

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -48,7 +48,7 @@
         row.with_cell(text: 'UV')
         @forecasts.map { | forecast|
           row.with_cell(
-            text: "#{forecast.uv.label} - #{forecast.uv.guidance}",
+            text: "#{forecast.uv.daqi_label} - #{forecast.uv.guidance}",
             html_attributes: { "data-date" => forecast.forecast_for}
           )
         }

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -56,7 +56,8 @@
         body.with_row(html_attributes: {class: "pollen"}) do |row|
           row.with_cell(text: 'Pollen')
           @forecasts.map { | forecast|
-            row.with_cell(text: forecast.pollen,
+            row.with_cell(
+              text: [forecast.pollen.daqi_label, forecast.pollen.guidance].join(" - "),
               html_attributes: { "data-date" => forecast.forecast_for}
             )
           }

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -31,7 +31,7 @@
         head.with_row do |row|
         row.with_cell(text: '')
         @forecasts.map { |forecast|
-          row.with_cell(text: forecast.forecast_for.to_formatted_s(:short))
+          row.with_cell(text: forecast.date.to_formatted_s(:short))
         }
 
         end; end; table.with_body do |body|
@@ -40,7 +40,7 @@
         @forecasts.map { | forecast|
           row.with_cell(
             text: forecast.air_pollution.daqi_label,
-            html_attributes: { "data-date" => forecast.forecast_for}
+            html_attributes: { "data-date" => forecast.date}
           )
         }
         end;
@@ -49,7 +49,7 @@
         @forecasts.map { | forecast|
           row.with_cell(
             text: "#{forecast.uv.daqi_label} - #{forecast.uv.guidance}",
-            html_attributes: { "data-date" => forecast.forecast_for}
+            html_attributes: { "data-date" => forecast.date}
           )
         }
         end;
@@ -58,7 +58,7 @@
           @forecasts.map { | forecast|
             row.with_cell(
               text: [forecast.pollen.daqi_label, forecast.pollen.guidance].join(" - "),
-              html_attributes: { "data-date" => forecast.forecast_for}
+              html_attributes: { "data-date" => forecast.date}
             )
           }
         end;
@@ -67,7 +67,7 @@
           @forecasts.map { | forecast|
             row.with_cell(
               text: "#{forecast.temperature.min.round}-#{forecast.temperature.max.round}°C",
-              html_attributes: { "data-date" => forecast.forecast_for}
+              html_attributes: { "data-date" => forecast.date}
             )
           }
         end;

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -39,7 +39,7 @@
         row.with_cell(text: 'Air pollution')
         @forecasts.map { | forecast|
           row.with_cell(
-            text: forecast.air_pollution.overall_label,
+            text: forecast.air_pollution.daqi_label,
             html_attributes: { "data-date" => forecast.forecast_for}
           )
         }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,13 @@ en:
   hello: "Hello world"
   prediction:
     guidance:
+      uv:
+        low: "No action required. You can safely stay outside."
+        moderate:
+          "Protection required. Seek shade during midday hours, cover up and
+          wear suncream."
+        high: "UV guidance for *high* DAQI level"
+        very_high: "UV guidance for *very high* DAQI level"
       pollen:
         low: "Pollen guidance for *low* DAQI level"
         moderate: "Pollen guidance for *moderate* DAQI level"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,13 @@ en:
     # TODO: Set new application name
     name: "airTEXT"
   hello: "Hello world"
+  prediction:
+    guidance:
+      pollen:
+        low: "Pollen guidance for *low* DAQI level"
+        moderate: "Pollen guidance for *moderate* DAQI level"
+        high: "Pollen guidance for *high* DAQI level"
+        very_high: "Pollen guidance for *very high* DAQI level"
   air_quality_alert:
     moderate:
       guidance:

--- a/spec/factories/air_pollutions_predictions.rb
+++ b/spec/factories/air_pollutions_predictions.rb
@@ -4,8 +4,8 @@
 #   @particulate_matter_10=1
 #   @particulate_matter_2_5=1
 #   @ozone=2
-#   @overall_score=2
-#   @overall_label=LOW>
+#   @value=2
+#   @label=LOW>
 
 FactoryBot.define do
   factory :air_pollution_prediction do
@@ -14,8 +14,44 @@ FactoryBot.define do
     particulate_matter_10 { 1 }
     particulate_matter_2_5 { 2 }
     ozone { 2 }
-    overall_score { 2 }
-    overall_label { "LOW" }
+    value { 2 }
+    label { "LOW" }
+
+    trait :low do
+      value { 2 }
+      label { "LOW" }
+      nitrogen_dioxide { 1 }
+      particulate_matter_10 { 1 }
+      particulate_matter_2_5 { 2 }
+      ozone { 2 }
+    end
+
+    trait :moderate do
+      value { 4 }
+      label { "MODERATE" }
+      nitrogen_dioxide { 4 }
+      particulate_matter_10 { 4 }
+      particulate_matter_2_5 { 4 }
+      ozone { 4 }
+    end
+
+    trait :high do
+      value { 8 }
+      label { "HIGH" }
+      nitrogen_dioxide { 8 }
+      particulate_matter_10 { 8 }
+      particulate_matter_2_5 { 8 }
+      ozone { 8 }
+    end
+
+    trait :very_high do
+      value { 10 }
+      label { "VERY HIGH" }
+      nitrogen_dioxide { 10 }
+      particulate_matter_10 { 10 }
+      particulate_matter_2_5 { 10 }
+      ozone { 10 }
+    end
 
     initialize_with {
       new(
@@ -24,8 +60,8 @@ FactoryBot.define do
         particulate_matter_10: particulate_matter_10,
         particulate_matter_2_5: particulate_matter_2_5,
         ozone: ozone,
-        overall_score: overall_score,
-        overall_label: overall_label
+        value: value,
+        label: label
       )
     }
   end

--- a/spec/factories/forecasts.rb
+++ b/spec/factories/forecasts.rb
@@ -11,8 +11,8 @@
 #   @particulate_matter_10=1
 #   @particulate_matter_2_5=1
 #   @ozone=2
-#   @overall_score=2
-#   @overall_label=LOW>
+#   @value=2
+#   @daqi_label=LOW>
 # @uv=2
 # @pollen=-999
 # @temperature=#<TemperaturePrediction

--- a/spec/factories/forecasts.rb
+++ b/spec/factories/forecasts.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     zone { FactoryBot.build(:forecast_zone) }
     air_pollution { FactoryBot.build(:air_pollution_prediction) }
     uv { FactoryBot.build(:uv_prediction) }
-    pollen { -999 }
+    pollen { FactoryBot.build(:pollen_prediction) }
     temperature { FactoryBot.build(:temperature_prediction) }
 
     initialize_with {

--- a/spec/factories/forecasts.rb
+++ b/spec/factories/forecasts.rb
@@ -1,6 +1,6 @@
 # #<Forecast
 # @obtained_at=2024-10-02 15:38:00 +0100
-# @forecast_for=2024-10-02
+# @date=2024-10-02
 # @zone=#<ForecastZone
 #   @id=29
 #   @name=Southwark
@@ -22,7 +22,7 @@
 FactoryBot.define do
   factory :forecast do
     obtained_at { Time.current }
-    forecast_for { Date.tomorrow }
+    date { Date.tomorrow }
     zone { FactoryBot.build(:forecast_zone) }
     air_pollution { FactoryBot.build(:air_pollution_prediction) }
     uv { FactoryBot.build(:uv_prediction) }
@@ -32,7 +32,7 @@ FactoryBot.define do
     initialize_with {
       new(
         obtained_at: obtained_at,
-        forecast_for: forecast_for,
+        date: date,
         zone: zone,
         air_pollution: air_pollution,
         uv: uv,

--- a/spec/factories/pollen_prediction.rb
+++ b/spec/factories/pollen_prediction.rb
@@ -1,0 +1,14 @@
+# @pollen=#<PollenPrediction
+#   @value=3
+
+FactoryBot.define do
+  factory :pollen_prediction do
+    value { 3 }
+
+    initialize_with {
+      new(
+        value: value
+      )
+    }
+  end
+end

--- a/spec/factories/uv_predictions.rb
+++ b/spec/factories/uv_predictions.rb
@@ -4,13 +4,11 @@
 
 FactoryBot.define do
   factory :uv_prediction do
-    level { 3 }
-    label { "Moderate" }
+    value { 3 }
 
     initialize_with {
       new(
-        level: level,
-        label: label
+        value: value
       )
     }
   end

--- a/spec/feature_steps/forecast_steps.rb
+++ b/spec/feature_steps/forecast_steps.rb
@@ -3,7 +3,7 @@ module ForecastSteps
     forecasts << Fixtures::API.build_forecast(
       day: :today,
       air_pollution_status: :high,
-      pollen: 4,
+      pollen: :low,
       temperature: :cold,
       uv: :low
     )
@@ -13,7 +13,7 @@ module ForecastSteps
     forecasts << Fixtures::API.build_forecast(
       day: :tomorrow,
       air_pollution_status: :moderate,
-      pollen: 5,
+      pollen: :moderate,
       temperature: :normal,
       uv: :moderate
     )
@@ -23,7 +23,7 @@ module ForecastSteps
     forecasts << Fixtures::API.build_forecast(
       day: :day_after_tomorrow,
       air_pollution_status: :very_high,
-      pollen: 6,
+      pollen: :high,
       temperature: :hot,
       uv: :high
     )
@@ -63,9 +63,9 @@ module ForecastSteps
   end
 
   def and_i_see_predicted_pollen_level_for_each_day
-    expect_prediction(day: :today, category: :pollen, value: 4)
-    expect_prediction(day: :tomorrow, category: :pollen, value: 5)
-    expect_prediction(day: :day_after_tomorrow, category: :pollen, value: 6)
+    expect_prediction(day: :today, category: :pollen, value: content_for_pollen(:low))
+    expect_prediction(day: :tomorrow, category: :pollen, value: content_for_pollen(:moderate))
+    expect_prediction(day: :day_after_tomorrow, category: :pollen, value: content_for_pollen(:high))
   end
 
   def and_i_see_predicted_temperature_for_each_day
@@ -136,6 +136,21 @@ module ForecastSteps
       "Very high- some very high UV guidance"
     else
       raise "Unexpected UV value #{value}"
+    end
+  end
+
+  def content_for_pollen(value)
+    case value
+    when :low
+      "Low - #{I18n.t("prediction.guidance.pollen.#{value}")}"
+    when :moderate
+      "Moderate - #{I18n.t("prediction.guidance.pollen.#{value}")}"
+    when :high
+      "High - #{I18n.t("prediction.guidance.pollen.#{value}")}"
+    when :very_high
+      "Very high - #{I18n.t("prediction.guidance.pollen.#{value}")}"
+    else
+      raise "Unexpected Pollen value #{value}"
     end
   end
 end

--- a/spec/feature_steps/forecast_steps.rb
+++ b/spec/feature_steps/forecast_steps.rb
@@ -127,13 +127,13 @@ module ForecastSteps
   def content_for_uv(value)
     case value
     when :low
-      "Low - No action required. You can safely stay outside."
+      "Low - #{I18n.t("prediction.guidance.uv.#{value}")}"
     when :moderate
-      "Moderate - Protection required. Seek shade during midday hours, cover up and wear suncream."
+      "Moderate - #{I18n.t("prediction.guidance.uv.#{value}")}"
     when :high
-      "High - some high UV guidance"
+      "High - #{I18n.t("prediction.guidance.uv.#{value}")}"
     when :very_high
-      "Very high- some very high UV guidance"
+      "Very high - #{I18n.t("prediction.guidance.uv.#{value}")}"
     else
       raise "Unexpected UV value #{value}"
     end

--- a/spec/fixtures/api/forecasts.rb
+++ b/spec/fixtures/api/forecasts.rb
@@ -16,7 +16,7 @@ module Fixtures
             "rain_pm": 3.01,
             "temp_max": #{max_temp_for(temperature)},
             "temp_min": #{min_temp_for(temperature)},
-            "total": "#{daqi_value_for_level(air_pollution_status)}",
+            "total": #{daqi_value_for_level(air_pollution_status)},
             "total_status": "#{total_status_for(air_pollution_status)}",
             "uv": #{daqi_value_for_level(uv)},
             "wind_am": 5.3,

--- a/spec/fixtures/api/forecasts.rb
+++ b/spec/fixtures/api/forecasts.rb
@@ -16,28 +16,13 @@ module Fixtures
             "rain_pm": 3.01,
             "temp_max": #{max_temp_for(temperature)},
             "temp_min": #{min_temp_for(temperature)},
-            "total": "#{total_for(air_pollution_status)}",
+            "total": "#{daqi_value_for_level(air_pollution_status)}",
             "total_status": "#{total_status_for(air_pollution_status)}",
-            "uv": #{uv_for(uv)},
+            "uv": #{daqi_value_for_level(uv)},
             "wind_am": 5.3,
             "wind_pm": 6.0
           }
         JSON
-      end
-
-      def uv_for(level)
-        case level
-        when :low
-          [1, 2, 3].sample
-        when :moderate
-          [4, 5, 6].sample
-        when :high
-          [7, 8, 9].sample
-        when :very_high
-          10
-        else
-          raise "UV: level of #{level} not expected"
-        end
       end
 
       def min_temp_for(temperature)
@@ -81,19 +66,6 @@ module Fixtures
         date.iso8601
       end
 
-      def total_for(air_pollution_status)
-        case air_pollution_status
-        when :low
-          [1, 2, 3].sample
-        when :moderate
-          [4, 5, 6].sample
-        when :high
-          [7, 8, 9].sample
-        when :very_high
-          10
-        end
-      end
-
       def total_status_for(air_pollution_status)
         case air_pollution_status
         when :low
@@ -124,6 +96,21 @@ module Fixtures
             ]
           }
         JSON
+      end
+
+      def daqi_value_for_level(daqi_level)
+        case daqi_level
+        when :low
+          [1, 2, 3].sample
+        when :moderate
+          [4, 5, 6].sample
+        when :high
+          [7, 8, 9].sample
+        when :very_high
+          10
+        else
+          raise "DAQI level of #{level} not known"
+        end
       end
     end
   end

--- a/spec/fixtures/api/forecasts.rb
+++ b/spec/fixtures/api/forecasts.rb
@@ -1,7 +1,7 @@
 module Fixtures
   module API
     class << self
-      def build_forecast(day:, air_pollution_status:, pollen: 4, temperature: :normal, uv: :moderate)
+      def build_forecast(day:, air_pollution_status:, pollen: :moderate, temperature: :normal, uv: :moderate)
         <<~JSON
           {
             "NO2": 1,
@@ -10,7 +10,7 @@ module Fixtures
             "PM2.5": 1,
             "forecast_date": "#{forecast_date_for(day)}",
             "non_pollution_version": null,
-            "pollen": #{pollen},
+            "pollen": #{daqi_value_for_level(pollen)},
             "pollution_version": 202410011407,
             "rain_am": 1.31,
             "rain_pm": 3.01,

--- a/spec/lib/forecast_factory_spec.rb
+++ b/spec/lib/forecast_factory_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ForecastFactory do
 
       aggregate_failures do
         expect(forecast.obtained_at).to eq(Time.zone.parse("02-10-2024 15:38"))
-        expect(forecast.forecast_for).to eq(Date.parse("2024-10-02"))
+        expect(forecast.date).to eq(Date.parse("2024-10-02"))
 
         expect(forecast.zone.name).to eq("Southwark")
         expect(forecast.zone.id).to eq(29)

--- a/spec/lib/forecast_factory_spec.rb
+++ b/spec/lib/forecast_factory_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ForecastFactory do
              "rain_pm" => 0.66,
              "temp_max" => 16.6,
              "temp_min" => 10.0,
-             "total" => 2,
+             "total" => 10,
              "total_status" => "VERY HIGH",
              "uv" => 2,
              "wind_am" => 4.9,
@@ -51,8 +51,9 @@ RSpec.describe ForecastFactory do
         expect(forecast.air_pollution.particulate_matter_10).to eq(1)
         expect(forecast.air_pollution.particulate_matter_2_5).to eq(1)
         expect(forecast.air_pollution.ozone).to eq(2)
-        expect(forecast.air_pollution.overall_score).to eq(2)
-        expect(forecast.air_pollution.overall_label).to eq("Very high")
+        expect(forecast.air_pollution.value).to eq(10)
+        expect(forecast.air_pollution.daqi_label).to eq("Very high")
+        expect(forecast.air_pollution.daqi_level).to eq(:very_high)
 
         expect(forecast.uv.value).to eq(2)
         expect(forecast.uv.daqi_label).to eq("Low")

--- a/spec/lib/forecast_factory_spec.rb
+++ b/spec/lib/forecast_factory_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ForecastFactory do
         expect(forecast.uv.label).to eq("Low")
         expect(forecast.uv.guidance).to eq("No action required. You can safely stay outside.")
 
-        expect(forecast.pollen).to eq(-999)
+        expect(forecast.pollen.value).to eq(-999)
 
         expect(forecast.temperature.min).to eq(10.0)
         expect(forecast.temperature.max).to eq(16.6)

--- a/spec/lib/forecast_factory_spec.rb
+++ b/spec/lib/forecast_factory_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe ForecastFactory do
         expect(forecast.air_pollution.overall_score).to eq(2)
         expect(forecast.air_pollution.overall_label).to eq("Very high")
 
-        expect(forecast.uv.level).to eq(2)
-        expect(forecast.uv.label).to eq("Low")
+        expect(forecast.uv.value).to eq(2)
+        expect(forecast.uv.daqi_label).to eq("Low")
         expect(forecast.uv.guidance).to eq("No action required. You can safely stay outside.")
 
         expect(forecast.pollen.value).to eq(-999)

--- a/spec/models/air_quality_alert_spec.rb
+++ b/spec/models/air_quality_alert_spec.rb
@@ -3,11 +3,7 @@ RSpec.describe AirQualityAlert do
     FactoryBot.build(
       :forecast,
       forecast_for: Date.tomorrow,
-      air_pollution: FactoryBot.build(
-        :air_pollution_prediction,
-        overall_label: "HIGH",
-        overall_score: 8
-      )
+      air_pollution: FactoryBot.build(:air_pollution_prediction, :high)
     )
   end
 
@@ -20,14 +16,11 @@ RSpec.describe AirQualityAlert do
   end
 
   describe "tag_colour" do
-    context "when the #level is 'moderate'" do
+    context "when the #daqi_level is 'moderate'" do
       let(:forecast) do
         FactoryBot.build(
           :forecast,
-          air_pollution: FactoryBot.build(
-            :air_pollution_prediction,
-            overall_label: "MODERATE"
-          )
+          air_pollution: FactoryBot.build(:air_pollution_prediction, :moderate)
         )
       end
 
@@ -38,14 +31,11 @@ RSpec.describe AirQualityAlert do
       end
     end
 
-    context "when the #level is 'high'" do
+    context "when the #daqi_level is 'high'" do
       let(:forecast) do
         FactoryBot.build(
           :forecast,
-          air_pollution: FactoryBot.build(
-            :air_pollution_prediction,
-            overall_label: "HIGH"
-          )
+          air_pollution: FactoryBot.build(:air_pollution_prediction, :high)
         )
       end
 
@@ -56,14 +46,11 @@ RSpec.describe AirQualityAlert do
       end
     end
 
-    context "when the #level is 'very high'" do
+    context "when the #daqi_level is 'very high'" do
       let(:forecast) do
         FactoryBot.build(
           :forecast,
-          air_pollution: FactoryBot.build(
-            :air_pollution_prediction,
-            overall_label: "VERY HIGH"
-          )
+          air_pollution: FactoryBot.build(:air_pollution_prediction, :very_high)
         )
       end
 
@@ -75,15 +62,21 @@ RSpec.describe AirQualityAlert do
     end
   end
 
-  describe "#level" do
-    it "returns the associated forecast's air pollution prediction's overall_label" do
-      expect(alert.level).to eq("High")
+  describe "#daqi_label" do
+    it "returns the associated forecast's air pollution prediction's daqi_label" do
+      expect(alert.daqi_label).to eq("High")
     end
   end
 
-  describe "#score" do
-    it "returns the associated forecast's air pollution prediction's overall_score" do
-      expect(alert.score).to eq(8)
+  describe "#daqi_level" do
+    it "returns the associated forecast's air pollution prediction's daqi_level" do
+      expect(alert.daqi_level).to eq(:high)
+    end
+  end
+
+  describe "#value" do
+    it "returns the associated forecast's air pollution prediction's value" do
+      expect(alert.value).to be >= (7)
     end
   end
 end

--- a/spec/models/air_quality_alert_spec.rb
+++ b/spec/models/air_quality_alert_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe AirQualityAlert do
   let(:forecast) do
     FactoryBot.build(
       :forecast,
-      forecast_for: Date.tomorrow,
+      date: Date.tomorrow,
       air_pollution: FactoryBot.build(:air_pollution_prediction, :high)
     )
   end

--- a/spec/models/forecast_spec.rb
+++ b/spec/models/forecast_spec.rb
@@ -7,10 +7,7 @@ RSpec.describe Forecast do
       let(:forecast) do
         FactoryBot.build(
           :forecast,
-          air_pollution: FactoryBot.build(
-            :air_pollution_prediction,
-            overall_label: "HIGH"
-          )
+          air_pollution: FactoryBot.build(:air_pollution_prediction, :high)
         )
       end
 
@@ -23,10 +20,7 @@ RSpec.describe Forecast do
       let(:forecast) do
         FactoryBot.build(
           :forecast,
-          air_pollution: FactoryBot.build(
-            :air_pollution_prediction,
-            overall_label: "LOW"
-          )
+          air_pollution: FactoryBot.build(:air_pollution_prediction, :low)
         )
       end
 
@@ -40,14 +34,11 @@ RSpec.describe Forecast do
     let(:alert) { double("air quality alert") }
     before { allow(AirQualityAlert).to receive(:new).and_return(alert) }
 
-    context "when the air pollution overall status is LOW" do
+    context "when the air pollution overall DAQI level is LOW" do
       let(:forecast) do
         FactoryBot.build(
           :forecast,
-          air_pollution: FactoryBot.build(
-            :air_pollution_prediction,
-            overall_label: "LOW"
-          )
+          air_pollution: FactoryBot.build(:air_pollution_prediction, :low)
         )
       end
 
@@ -56,15 +47,12 @@ RSpec.describe Forecast do
       end
     end
 
-    context "when the air pollution overall status not LOW" do
-      ["MODERATE", "HIGH", "VERY HIGH"].each do |status|
+    context "when the air pollution overall DAQI level is not LOW" do
+      [:moderate, :high, :very_high].each do |daqi_level|
         let(:forecast) do
           FactoryBot.build(
             :forecast,
-            air_pollution: FactoryBot.build(
-              :air_pollution_prediction,
-              overall_label: status
-            )
+            air_pollution: FactoryBot.build(:air_pollution_prediction, daqi_level)
           )
         end
 

--- a/spec/models/uv_prediction_spec.rb
+++ b/spec/models/uv_prediction_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe UvPrediction do
-  describe "#label_text" do
+  describe "#daqi_label and #guidance" do
     context "when the UV level is 1, 2 or 3" do
       [1, 2, 3].each do |value|
         prediction = UvPrediction.new(value)
         it "returns _Low_ with guidance" do
-          expect(prediction.label).to eq("Low")
-          expect(prediction.guidance).to eq("No action required. You can safely stay outside.")
+          expect(prediction.daqi_label).to eq("Low")
+          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.uv.low"))
         end
       end
     end
@@ -14,8 +14,8 @@ RSpec.describe UvPrediction do
       [4, 5, 6].each do |value|
         prediction = UvPrediction.new(value)
         it "returns _Moderate_ with guidance" do
-          expect(prediction.label).to eq("Moderate")
-          expect(prediction.guidance).to eq("Protection required. Seek shade during midday hours, cover up and wear suncream.")
+          expect(prediction.daqi_label).to eq("Moderate")
+          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.uv.moderate"))
         end
       end
     end
@@ -24,8 +24,8 @@ RSpec.describe UvPrediction do
       [7, 8, 9].each do |level|
         prediction = UvPrediction.new(level)
         it "returns _High_ with guidance" do
-          expect(prediction.label).to eq("High")
-          expect(prediction.guidance).to eq("some high UV guidance")
+          expect(prediction.daqi_label).to eq("High")
+          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.uv.high"))
         end
       end
     end
@@ -33,8 +33,8 @@ RSpec.describe UvPrediction do
     context "when the UV level is 10" do
       prediction = UvPrediction.new(10)
       it "returns _Very high_ with guidance" do
-        expect(prediction.label).to eq("Very high")
-        expect(prediction.guidance).to eq("some very high UV guidance")
+        expect(prediction.daqi_label).to eq("Very high")
+        expect(prediction.guidance).to eq(I18n.t("prediction.guidance.uv.very_high"))
       end
     end
   end


### PR DESCRIPTION
See [Trello 63](63-show-recommended-action)

In this PR we add guidance text for "pollen predictions" in the matrix of 3 day forecasts:

<img width="960" alt="guidance_for_pollen_predictions" src="https://github.com/user-attachments/assets/eb3a47e0-e856-47a3-bca9-11d71494fe90">

We don't add any more content for other rows at this point:

### Air pollution
This is currently well developed in the Air Quality Alerts which are current shown above the table of 3 day predictions:

![alert_expanded_solo](https://github.com/user-attachments/assets/14f39456-12e5-4770-96a5-548c55f18e52)

### Temperature

We can easily add this in later.

We've done some refactoring to make our "predictions" more consistent:

- created a `DaqiProperties` module to share `#daqi_level` (e.g. `:moderate`) and `#daqi_label` e.g. `"Moderate"`, and always use `@value` for the numeric score 1 to 10
- put guidance text into our `en.yml` "translation" file

