### PR TITLE
Update forecast predictions on tab click

### DIFF
--- a/app/controllers/styled_forecasts_controller.rb
+++ b/app/controllers/styled_forecasts_controller.rb
@@ -4,4 +4,24 @@ class StyledForecastsController < ApplicationController
     @forecasts = CercApiClient
       .forecasts_for(params.fetch("zone", "Southwark"))
   end
+
+  def update
+    forecasts = CercApiClient
+      .forecasts_for(params.fetch("zone", "Southwark"))
+
+    day_forecast = forecast_for_day(params.fetch("day"), forecasts)
+
+    render turbo_stream: turbo_stream.replace("day_predictions", partial: "predictions", locals: {forecast: day_forecast})
+  end
+
+  def forecast_for_day(day, forecasts)
+    case day
+    when "today"
+      forecasts.first
+    when "tomorrow"
+      forecasts.second
+    when "day_after_tomorrow"
+      forecasts.third
+    end
+  end
 end

--- a/app/controllers/styled_forecasts_controller.rb
+++ b/app/controllers/styled_forecasts_controller.rb
@@ -22,6 +22,8 @@ class StyledForecastsController < ApplicationController
       forecasts.second
     when "day_after_tomorrow"
       forecasts.third
+    else
+      raise ArgumentError, "Invalid day: #{day}"
     end
   end
 end

--- a/app/views/styled_forecasts/_day_tab.html.erb
+++ b/app/views/styled_forecasts/_day_tab.html.erb
@@ -1,4 +1,6 @@
 <div class="tab py-4 flex-1 today mx-2 px-1 text-center daqi-low border-b-0 border-l-2 border-r-2 border-t-2 border-gray-300" data-date="<%= forecast.date %>" >
+<%= link_to update_styled_forecast_path(day: day), data: { turbo_frame: "day_predictions" } do %>
+
   <div class="day">
     <%= forecast.date == Date.today ? 'Today' : forecast.date.strftime('%A') %>
   </div>
@@ -14,4 +16,5 @@
   <div class="daqi-value font-normal">
     Index <%= forecast.air_pollution.value %>/10
   </div>
+  <% end %>
 </div>

--- a/app/views/styled_forecasts/_forecast_tabs.html.erb
+++ b/app/views/styled_forecasts/_forecast_tabs.html.erb
@@ -2,10 +2,10 @@
   <header class="text-xl px-4 font-bold">
     Air pollution
   </header>
-  <div class="tabs flex flex-row items-stretch mt-4 m-1 text-xs font-bold ">
-    <%= render "day_tab", forecast: @forecasts.first %>
-    <%= render "day_tab", forecast: @forecasts.second %>
-    <%= render "day_tab", forecast: @forecasts.third %>
+  <div class="tabs flex flex-row items-stretch mt-4 m-1 text-xs font-bold" data-turbo-prefetch="false">
+    <%= render "day_tab", forecast: @forecasts.first, day: :today %>
+    <%= render "day_tab", forecast: @forecasts.second, day: :tomorrow %>
+    <%= render "day_tab", forecast: @forecasts.third, day: :day_after_tomorrow %>
   </div>
   <%= render partial: "map_selector" %>
   <div id="map" class="map w-full bg-green-200 h-80">

--- a/app/views/styled_forecasts/_predictions.html.erb
+++ b/app/views/styled_forecasts/_predictions.html.erb
@@ -1,5 +1,7 @@
-<dl class="predictions p-4">
-  <%= render(PredictionComponent.new(prediction: @forecasts.first.uv)) %>
-  <%= render(PredictionComponent.new(prediction: @forecasts.first.pollen)) %>
-  <%= render "temperature_prediction", prediction: @forecasts.first.temperature %>
-</dl>
+<%= turbo_frame_tag "day_predictions" do %>
+  <dl class="predictions p-4">
+    <%= render(PredictionComponent.new(prediction: forecast.uv)) %>
+    <%= render(PredictionComponent.new(prediction: forecast.pollen)) %>
+    <%= render "temperature_prediction", prediction: forecast.temperature %>
+  </dl>
+<% end %>

--- a/app/views/styled_forecasts/show.html.erb
+++ b/app/views/styled_forecasts/show.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "styled_forecasts/location" %>
 <%= render partial: "styled_forecasts/forecast_tabs", forecasts: @forecasts %>
-<%= render partial: "styled_forecasts/predictions" %>
+<%= render partial: "styled_forecasts/predictions", locals: { forecast: @forecasts.first } %>
 <%= render partial: "sharing" %>
 <%= render partial: "learning" %>
 <%= render partial: "subscribe" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   get :forecast, to: "forecasts#show"
   get :styled_forecast, to: "styled_forecasts#show"
+  get :update_styled_forecast, to: "styled_forecasts#update"
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that
   # hostname, redirect us to the canonical hostname with the path and query string present


### PR DESCRIPTION
## Changes in this PR

Allows UV, pollen and temperature predictions to update on clicking one of the day tabs, using turbo streams.

## Screenshots of UI changes

### Before

### After

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
