### PR TITLE
80 update forecast predictions on tab click

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ RUN \
   apt-get update && \
   apt-get install -y \
   shellcheck \
+  chromium-driver \
   yarn
 
 RUN yarn build:css && yarn build

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ end
 
 group :test do
   gem "capybara", ">= 2.15"
+  gem "cuprite"
   gem "database_cleaner"
   gem "launchy"
   gem "selenium-webdriver"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,9 @@ GEM
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     csv (3.3.0)
+    cuprite (0.15.1)
+      capybara (~> 3.0)
+      ferrum (~> 0.15.0)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.2.0)
@@ -143,6 +146,11 @@ GEM
       railties (>= 5.0.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
+    ferrum (0.15)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -459,6 +467,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   climate_control
   cssbundling-rails (~> 1.4)
+  cuprite
   database_cleaner
   dotenv-rails
   factory_bot_rails

--- a/app/controllers/styled_forecasts_controller.rb
+++ b/app/controllers/styled_forecasts_controller.rb
@@ -4,4 +4,30 @@ class StyledForecastsController < ApplicationController
     @forecasts = CercApiClient
       .forecasts_for(params.fetch("zone", "Southwark"))
   end
+
+  def update
+    forecasts = CercApiClient
+      .forecasts_for(params.fetch("zone", "Southwark"))
+
+    day_forecast = forecast_for_day(params.fetch("day"), forecasts)
+
+    render turbo_stream: turbo_stream.replace(
+      "day_predictions",
+      partial: "predictions",
+      locals: {forecast: day_forecast}
+    )
+  end
+
+  def forecast_for_day(day, forecasts)
+    case day
+    when "today"
+      forecasts.first
+    when "tomorrow"
+      forecasts.second
+    when "day_after_tomorrow"
+      forecasts.third
+    else
+      raise ArgumentError, "Invalid day: #{day}"
+    end
+  end
 end

--- a/app/models/uv_prediction.rb
+++ b/app/models/uv_prediction.rb
@@ -8,11 +8,11 @@ class UvPrediction
   end
 
   def name
-    "Ultravoilet rays (UV)"
+    "Ultraviolet rays (UV)"
   end
 
   def guidance
-    I18n.t("prediction.guidance.uv.#{daqi_level}")
+    I18n.t("prediction.guidance.ultraviolet_rays_uv.#{daqi_level}")
   end
 
   # :nocov:

--- a/app/views/styled_forecasts/_day_tab.html.erb
+++ b/app/views/styled_forecasts/_day_tab.html.erb
@@ -1,4 +1,6 @@
 <div class="tab py-4 flex-1 today mx-2 px-1 text-center daqi-low border-b-0 border-l-2 border-r-2 border-t-2 border-gray-300" data-date="<%= forecast.date %>" >
+<%= link_to update_styled_forecast_path(day: day), data: { turbo_frame: "day_predictions" } do %>
+
   <div class="day">
     <%= forecast.date == Date.today ? 'Today' : forecast.date.strftime('%A') %>
   </div>
@@ -14,4 +16,5 @@
   <div class="daqi-value font-normal">
     Index <%= forecast.air_pollution.value %>/10
   </div>
+  <% end %>
 </div>

--- a/app/views/styled_forecasts/_day_tab.html.erb
+++ b/app/views/styled_forecasts/_day_tab.html.erb
@@ -1,20 +1,19 @@
-<div class="tab py-4 flex-1 today mx-2 px-1 text-center daqi-low border-b-0 border-l-2 border-r-2 border-t-2 border-gray-300" data-date="<%= forecast.date %>" >
-<%= link_to update_styled_forecast_path(day: day), data: { turbo_frame: "day_predictions" } do %>
-
-  <div class="day">
-    <%= forecast.date == Date.today ? 'Today' : forecast.date.strftime('%A') %>
-  </div>
-  <div class="date">
-    <%= forecast.date.strftime("%d %B") %>
-  </div>
-  <div class="daqi-marker text-4xl py-2 text-green-600">
-   ●
-  </div>
-  <div class="daqi-label text-base">
-    <%= forecast.air_pollution.label.capitalize %>
-  </div>
-  <div class="daqi-value font-normal">
-    Index <%= forecast.air_pollution.value %>/10
-  </div>
+<div class="tab py-4 flex-1 <%= day %> mx-2 px-1 text-center daqi-low border-b-0 border-l-2 border-r-2 border-t-2 border-gray-300" data-date="<%= forecast.date %>" >
+  <%= link_to update_styled_forecast_path(day: day), data: { turbo_frame: "day_predictions" } do %>
+    <div class="day">
+      <%= forecast.date == Date.today ? 'Today' : forecast.date.strftime('%A') %>
+    </div>
+    <div class="date">
+      <%= forecast.date.strftime("%d %B") %>
+    </div>
+    <div class="daqi-marker text-4xl py-2 text-green-600">
+      ●
+    </div>
+    <div class="daqi-label text-base">
+      <%= forecast.air_pollution.label.capitalize %>
+    </div>
+    <div class="daqi-value font-normal">
+      Index <%= forecast.air_pollution.value %>/10
+    </div>
   <% end %>
 </div>

--- a/app/views/styled_forecasts/_forecast_tabs.html.erb
+++ b/app/views/styled_forecasts/_forecast_tabs.html.erb
@@ -2,10 +2,10 @@
   <header class="text-xl px-4 font-bold">
     Air pollution
   </header>
-  <div class="tabs flex flex-row items-stretch mt-4 m-1 text-xs font-bold ">
-    <%= render "day_tab", forecast: @forecasts.first %>
-    <%= render "day_tab", forecast: @forecasts.second %>
-    <%= render "day_tab", forecast: @forecasts.third %>
+  <div class="tabs flex flex-row items-stretch mt-4 m-1 text-xs font-bold" data-turbo-prefetch="false">
+    <%= render "day_tab", forecast: @forecasts.first, day: :today %>
+    <%= render "day_tab", forecast: @forecasts.second, day: :tomorrow %>
+    <%= render "day_tab", forecast: @forecasts.third, day: :day_after_tomorrow %>
   </div>
   <%= render partial: "map_selector" %>
   <div id="map" class="map w-full bg-green-200 h-80">

--- a/app/views/styled_forecasts/_predictions.html.erb
+++ b/app/views/styled_forecasts/_predictions.html.erb
@@ -1,5 +1,7 @@
-<dl class="predictions p-4">
-  <%= render(PredictionComponent.new(prediction: @forecasts.first.uv)) %>
-  <%= render(PredictionComponent.new(prediction: @forecasts.first.pollen)) %>
-  <%= render "temperature_prediction", prediction: @forecasts.first.temperature %>
-</dl>
+<%= turbo_frame_tag "day_predictions" do %>
+  <dl class="predictions p-4">
+    <%= render(PredictionComponent.new(prediction: forecast.uv)) %>
+    <%= render(PredictionComponent.new(prediction: forecast.pollen)) %>
+    <%= render "temperature_prediction", prediction: forecast.temperature %>
+  </dl>
+<% end %>

--- a/app/views/styled_forecasts/show.html.erb
+++ b/app/views/styled_forecasts/show.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "styled_forecasts/location" %>
 <%= render partial: "styled_forecasts/forecast_tabs", forecasts: @forecasts %>
-<%= render partial: "styled_forecasts/predictions" %>
+<%= render partial: "styled_forecasts/predictions", locals: { forecast: @forecasts.first } %>
 <%= render partial: "sharing" %>
 <%= render partial: "learning" %>
 <%= render partial: "subscribe" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
   hello: "Hello world"
   prediction:
     guidance:
-      uv:
+      ultraviolet_rays_uv:
         low: "No action required. You can safely stay outside."
         moderate:
           "Protection required. Seek shade during midday hours, cover up and

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   get :forecast, to: "forecasts#show"
   get :styled_forecast, to: "styled_forecasts#show"
+  get :update_styled_forecast, to: "styled_forecasts#update"
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that
   # hostname, redirect us to the canonical hostname with the path and query string present

--- a/spec/controllers/styled_forecasts_controller_spec.rb
+++ b/spec/controllers/styled_forecasts_controller_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe StyledForecastsController do
       get :show
 
       expect(CercApiClient).to have_received(:forecasts_for).with("Southwark")
-      expect(response).to render_template("show")
     end
 
     it "renders the _show_ template" do

--- a/spec/controllers/styled_forecasts_controller_spec.rb
+++ b/spec/controllers/styled_forecasts_controller_spec.rb
@@ -7,46 +7,84 @@ RSpec.describe StyledForecastsController do
     ClimateControl.modify(env_vars) { example.run }
   end
 
+  let(:forecast_from_api) do
+    {
+      "forecastdate" => "01-10-2024 14:40",
+      "timestamp" => 1727793654317.342,
+      "zones" => [
+        {
+          "forecasts" => [
+            {
+              "NO2" => 1,
+              "O3" => 2,
+              "PM10" => 1,
+              "PM2.5" => 1,
+              "forecast_date" => "2024-10-01",
+              "non_pollution_version" => nil,
+              "pollen" => -999,
+              "pollution_version" => 202410011407,
+              "rain_am" => 1.31,
+              "rain_pm" => 3.01,
+              "temp_max" => 14.0,
+              "temp_min" => 10.4,
+              "total" => 2,
+              "total_status" => "LOW",
+              "uv" => 1,
+              "wind_am" => 5.3,
+              "wind_pm" => 6.0
+            },
+            {
+              "NO2" => 1,
+              "O3" => 2,
+              "PM10" => 1,
+              "PM2.5" => 1,
+              "forecast_date" => "2024-10-02",
+              "non_pollution_version" => nil,
+              "pollen" => -999,
+              "pollution_version" => 202410011407,
+              "rain_am" => 1.31,
+              "rain_pm" => 3.01,
+              "temp_max" => 14.0,
+              "temp_min" => 10.4,
+              "total" => 2,
+              "total_status" => "LOW",
+              "uv" => 1,
+              "wind_am" => 5.3,
+              "wind_pm" => 6.0
+            },
+            {
+              "NO2" => 1,
+              "O3" => 2,
+              "PM10" => 1,
+              "PM2.5" => 1,
+              "forecast_date" => "2024-10-03",
+              "non_pollution_version" => nil,
+              "pollen" => -999,
+              "pollution_version" => 202410011407,
+              "rain_am" => 1.31,
+              "rain_pm" => 3.01,
+              "temp_max" => 14.0,
+              "temp_min" => 10.4,
+              "total" => 2,
+              "total_status" => "LOW",
+              "uv" => 1,
+              "wind_am" => 5.3,
+              "wind_pm" => 6.0
+            }
+          ],
+          "zone_id" => 14,
+          "zone_name" => "Haringey",
+          "zone_type" => 1
+        }
+      ]
+    }
+  end
+
+  let(:forecasts) do
+    ForecastFactory.build(forecast_from_api)
+  end
+
   describe "GET :show" do
-    let(:forecast_from_api) do
-      {
-        "forecastdate" => "01-10-2024 14:40",
-        "timestamp" => 1727793654317.342,
-        "zones" => [
-          {
-            "forecasts" => [
-              {
-                "NO2" => 1,
-                "O3" => 2,
-                "PM10" => 1,
-                "PM2.5" => 1,
-                "forecast_date" => "2024-10-01",
-                "non_pollution_version" => nil,
-                "pollen" => -999,
-                "pollution_version" => 202410011407,
-                "rain_am" => 1.31,
-                "rain_pm" => 3.01,
-                "temp_max" => 14.0,
-                "temp_min" => 10.4,
-                "total" => 2,
-                "total_status" => "LOW",
-                "uv" => 1,
-                "wind_am" => 5.3,
-                "wind_pm" => 6.0
-              }
-            ],
-            "zone_id" => 14,
-            "zone_name" => "Haringey",
-            "zone_type" => 1
-          }
-        ]
-      }
-    end
-
-    let(:forecasts) do
-      ForecastFactory.build(forecast_from_api)
-    end
-
     it "obtains forecasts for the default zone (Southwark) from the CercApiClient" do
       allow(CercApiClient).to receive(:forecasts_for).and_return(forecasts)
 
@@ -61,6 +99,77 @@ RSpec.describe StyledForecastsController do
       get :show
 
       expect(response).to render_template("show")
+    end
+  end
+
+  describe "GET :update" do
+    let(:forecasts) do
+      ForecastFactory.build(forecast_from_api)
+    end
+
+    let(:tag_builder) do
+      instance_double(Turbo::Streams::TagBuilder, replace: true)
+    end
+
+    before do
+      allow(Turbo::Streams::TagBuilder).to receive(:new).and_return(tag_builder)
+    end
+
+    context "when a recognised _day_ parameter is received" do
+      describe "when the day is _today_" do
+        it "passes the first forecast to the view" do
+          allow(CercApiClient).to receive(:forecasts_for).and_return(forecasts)
+
+          get :update, params: {day: :today}
+
+          expect(CercApiClient).to have_received(:forecasts_for).with("Southwark")
+          expect(tag_builder).to have_received(:replace).with(
+            "day_predictions",
+            partial: "predictions",
+            locals: {forecast: forecasts.first}
+          )
+        end
+      end
+
+      describe "when the day is _tomorrow_" do
+        it "passes the second forecast to the view" do
+          allow(CercApiClient).to receive(:forecasts_for).and_return(forecasts)
+
+          get :update, params: {day: :tomorrow}
+
+          expect(CercApiClient).to have_received(:forecasts_for).with("Southwark")
+          expect(tag_builder).to have_received(:replace).with(
+            "day_predictions",
+            partial: "predictions",
+            locals: {forecast: forecasts.second}
+          )
+        end
+      end
+
+      describe "when the day is _day_after_tomorrow_" do
+        it "passes the third forecast to the view" do
+          allow(CercApiClient).to receive(:forecasts_for).and_return(forecasts)
+
+          get :update, params: {day: :day_after_tomorrow}
+
+          expect(CercApiClient).to have_received(:forecasts_for).with("Southwark")
+          expect(tag_builder).to have_received(:replace).with(
+            "day_predictions",
+            partial: "predictions",
+            locals: {forecast: forecasts.third}
+          )
+        end
+      end
+    end
+
+    context "when an unrecognised _day_ parameter is received" do
+      it "raises a helpful error" do
+        allow(CercApiClient).to receive(:forecasts_for).and_return(forecasts)
+
+        expect {
+          get :update, params: {day: :yesterday}
+        }.to raise_error(ArgumentError, "Invalid day: yesterday")
+      end
     end
   end
 end

--- a/spec/feature_steps/forecast_steps.rb
+++ b/spec/feature_steps/forecast_steps.rb
@@ -46,6 +46,19 @@ module ForecastSteps
     click_link("View new style forecasts")
   end
 
+  def and_i_switch_to_the_tab_for_tomorrow
+    switch_to_tab_for(:tomorrow)
+  end
+
+  def switch_to_tab_for(day)
+    case day
+    when :tomorrow
+      find(".tab.tomorrow a").click
+    else
+      raise "day: #{day} not expected"
+    end
+  end
+
   def then_i_see_the_forecasts_page
     expect(page).to have_content("Forecasts")
   end
@@ -90,6 +103,18 @@ module ForecastSteps
 
   def and_i_see_predicted_uv_level_v2
     expect_prediction_v2(category: "ultraviolet-rays-uv", value: "Low")
+  end
+
+  def and_i_see_predicted_uv_level_for_tomorrow
+    expect_styled_prediction(category: :"ultraviolet-rays-uv", level: :moderate)
+  end
+
+  def and_i_see_predicted_pollen_level_for_tomorrow
+    expect_styled_prediction(category: :pollen, level: :moderate)
+  end
+
+  def and_i_see_predicted_temperature_level_for_tomorrow
+    expect_styled_prediction(category: :temperature, level: :moderate)
   end
 
   def and_i_see_predicted_pollen_level_v2

--- a/spec/feature_steps/forecast_steps.rb
+++ b/spec/feature_steps/forecast_steps.rb
@@ -89,7 +89,7 @@ module ForecastSteps
   end
 
   def and_i_see_predicted_uv_level_v2
-    expect_prediction_v2(category: "ultravoilet-rays-uv", value: "Low")
+    expect_prediction_v2(category: "ultraviolet-rays-uv", value: "Low")
   end
 
   def and_i_see_predicted_pollen_level_v2
@@ -165,13 +165,13 @@ module ForecastSteps
   def content_for_uv(value)
     case value
     when :low
-      "Low - #{I18n.t("prediction.guidance.uv.#{value}")}"
+      "Low - #{I18n.t("prediction.guidance.ultraviolet_rays_uv.#{value}")}"
     when :moderate
-      "Moderate - #{I18n.t("prediction.guidance.uv.#{value}")}"
+      "Moderate - #{I18n.t("prediction.guidance.ultraviolet_rays_uv.#{value}")}"
     when :high
-      "High - #{I18n.t("prediction.guidance.uv.#{value}")}"
+      "High - #{I18n.t("prediction.guidance.ultraviolet_rays_uv.#{value}")}"
     when :very_high
-      "Very high - #{I18n.t("prediction.guidance.uv.#{value}")}"
+      "Very high - #{I18n.t("prediction.guidance.ultraviolet_rays_uv.#{value}")}"
     else
       raise "Unexpected UV value #{value}"
     end

--- a/spec/feature_steps/forecast_steps.rb
+++ b/spec/feature_steps/forecast_steps.rb
@@ -114,6 +114,54 @@ module ForecastSteps
     end
   end
 
+  def expect_styled_prediction(category:, level:)
+    within(".#{category}") do
+      expect_styled_content_for(category:, level:)
+    end
+  end
+
+  def expect_styled_content_for(category:, level:)
+    case category
+    when :"ultraviolet-rays-uv"
+      expect_uv_content_for_level(level)
+    when :pollen
+      expect_pollen_content_for_level(level)
+    when :temperature
+      expect_temperature_content_for_level(level)
+    else
+      raise "category #{category} not implemented"
+    end
+  end
+
+  def expect_uv_content_for_level(level)
+    case level
+    when :moderate
+      expect(page).to have_content("Moderate")
+      expect(page).to have_content(I18n.t("prediction.guidance.ultraviolet_rays_uv.#{level}"))
+    else
+      raise "unexpected level #{level}"
+    end
+  end
+
+  def expect_pollen_content_for_level(level)
+    case level
+    when :moderate
+      expect(page).to have_content("Moderate")
+      expect(page).to have_content(I18n.t("prediction.guidance.pollen.#{level}"))
+    else
+      raise "unexpected level #{level}"
+    end
+  end
+
+  def expect_temperature_content_for_level(level)
+    case level
+    when :moderate
+      expect(page).to have_content("9°C - 16°C")
+    else
+      raise "unexpected level #{level}"
+    end
+  end
+
   def expect_air_pollution_prediction(day:, value:)
     within("div[data-date='#{date(day)}']") do
       expect(page).to have_content(content_for_air_pollution(value))

--- a/spec/features/visitors/view_styled_forecasts_spec.rb
+++ b/spec/features/visitors/view_styled_forecasts_spec.rb
@@ -29,4 +29,20 @@ RSpec.feature "Forecasts page" do
     and_i_see_predicted_pollen_level_v2
     and_i_see_predicted_temperature_level_v2
   end
+
+  scenario "See detail for tomorrow", js: true do
+    given_a_forecast_for_today
+    and_a_forecast_for_tomorrow
+    and_a_forecast_for_the_day_after_tomorrow
+    and_the_response_from_cercs_api_is_stubbed_accordingly
+
+    visit root_path
+    when_i_select_view_forecasts_v2
+    and_i_switch_to_the_tab_for_tomorrow
+
+    # then I see that the _tomorrow_ tab is active
+    and_i_see_predicted_uv_level_for_tomorrow
+    and_i_see_predicted_pollen_level_for_tomorrow
+    and_i_see_predicted_temperature_level_for_tomorrow
+  end
 end

--- a/spec/models/uv_prediction_spec.rb
+++ b/spec/models/uv_prediction_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UvPrediction do
         prediction = UvPrediction.new(value)
         it "returns _Low_ with guidance" do
           expect(prediction.daqi_label).to eq("Low")
-          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.uv.low"))
+          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.ultraviolet_rays_uv.low"))
         end
       end
     end
@@ -15,7 +15,7 @@ RSpec.describe UvPrediction do
         prediction = UvPrediction.new(value)
         it "returns _Moderate_ with guidance" do
           expect(prediction.daqi_label).to eq("Moderate")
-          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.uv.moderate"))
+          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.ultraviolet_rays_uv.moderate"))
         end
       end
     end
@@ -25,7 +25,7 @@ RSpec.describe UvPrediction do
         prediction = UvPrediction.new(level)
         it "returns _High_ with guidance" do
           expect(prediction.daqi_label).to eq("High")
-          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.uv.high"))
+          expect(prediction.guidance).to eq(I18n.t("prediction.guidance.ultraviolet_rays_uv.high"))
         end
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe UvPrediction do
       prediction = UvPrediction.new(10)
       it "returns _Very high_ with guidance" do
         expect(prediction.daqi_label).to eq("Very high")
-        expect(prediction.guidance).to eq(I18n.t("prediction.guidance.uv.very_high"))
+        expect(prediction.guidance).to eq(I18n.t("prediction.guidance.ultraviolet_rays_uv.very_high"))
       end
     end
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,4 +2,18 @@
 
 Dir[Rails.root.join("spec", "feature_steps", "**", "*.rb")].sort.each { |f| require f }
 
+require "capybara/cuprite"
+Capybara.default_max_wait_time = 5
+Capybara.disable_animation = true
+Capybara.javascript_driver = :cuprite
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(
+    app,
+    window_size: [1200, 800],
+    js_errors: true,
+    timeout: 10,
+    process_timeout: 15,
+    inspector: ENV["INSPECTOR"]
+  )
+end
 Capybara.asset_host = "http://localhost:3000"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,13 +7,17 @@ Capybara.default_max_wait_time = 5
 Capybara.disable_animation = true
 Capybara.javascript_driver = :cuprite
 Capybara.register_driver(:cuprite) do |app|
+  browser_options = {}.tap do |opts|
+    opts["no-sandbox"] = nil if ENV["CI"]
+  end
   Capybara::Cuprite::Driver.new(
     app,
     window_size: [1200, 800],
     js_errors: true,
     timeout: 10,
     process_timeout: 15,
-    inspector: ENV["INSPECTOR"]
+    inspector: ENV["INSPECTOR"],
+    browser_options: browser_options
   )
 end
 Capybara.asset_host = "http://localhost:3000"


### PR DESCRIPTION
Allows UV, temperature and pollen predictions to be updated to today/tomorrow/day after tomorrow, by clicking on the day tabs in the main air pollution prediction section of the forecast page.

We use Rails' turbo streams to achieve these dynamic updates.