### PR TITLE
Move from dotenv-rails to dot-env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
   gem "brakeman"
   gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
-  gem "dotenv-rails"
+  gem "dotenv"
   gem "factory_bot_rails"
   gem "faker"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,9 +132,6 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.0)
     dotenv (3.1.4)
-    dotenv-rails (3.1.4)
-      dotenv (= 3.1.4)
-      railties (>= 6.1)
     drb (2.2.1)
     e2mmap (0.1.0)
     erubi (1.13.0)
@@ -471,7 +468,7 @@ DEPENDENCIES
   cssbundling-rails (~> 1.4)
   cuprite
   database_cleaner
-  dotenv-rails
+  dotenv
   factory_bot_rails
   faker
   govuk-components


### PR DESCRIPTION
"The `dotenv-rails` gem is now superfluous. It's not technically deprecated yet and will continue to work, but the `dotenv` gem does the same thing."

https://github.com/bkeepers/dotenv/blob/main/Changelog.md#300

See change to dxw Rails Template: https://github.com/dxw/rails-template/pull/791

Thanks @yndajas

