### PR TITLE
Show OpenStreetMap as top layer over CERC colours

### DIFF
--- a/app/javascript/maps.js
+++ b/app/javascript/maps.js
@@ -5,8 +5,6 @@ document.addEventListener("turbo:load", function () {
   const mapEle = document.querySelector("#map");
 
   if (mapEle) {
-    console.log("map is on the page");
-
     const bigBenLatLng = [51.510357, -0.116773];
 
     const airTextBaseUrl = "https://airtext.info/geoserver/wms?";
@@ -17,8 +15,7 @@ document.addEventListener("turbo:load", function () {
       layers: "london:Total",
       time: todaysDate,
       format: "image/png",
-      opacity: 0.6,
-      transparency: true, // term used by CERC
+      opacity: 1,
     };
 
     const mergeAirTextOptions = (options) => {
@@ -35,27 +32,47 @@ document.addEventListener("turbo:load", function () {
       mergeAirTextOptions({ styles: "daqiTotal_linear" })
     );
 
-    const mtLayer = new L.MaptilerLayer({
-      apiKey: maptilerApiKey,
-      style: "positron",
-      transparent: false,
-    });
-
-    const overlayMaps = {
-      Discrete: discreteAir,
-      Linear: linearAir,
-    };
-    const baseMaps = {
-      MapTiler: mtLayer,
-    };
-
     const map = L.map("map", {
       center: bigBenLatLng,
       zoom: 8,
       layers: [discreteAir],
     });
-    map.addLayer(mtLayer);
 
-    L.control.layers(overlayMaps, baseMaps, { collapsed: false }).addTo(map);
+    map.createPane("osm");
+    map.getPane("osm").style.zIndex = 999;
+    map.getPane("osm").style.opacity = 0.6;
+
+    const tonerLite = new L.MaptilerLayer({
+      apiKey: maptilerApiKey,
+      style: "toner-v2-lite",
+      pane: "osm",
+    });
+
+    const basicLight = new L.MaptilerLayer({
+      apiKey: maptilerApiKey,
+      style: "basic-v2-light",
+      pane: "osm",
+    });
+
+    const streetsPastel = new L.MaptilerLayer({
+      apiKey: maptilerApiKey,
+      style: "streets-v2-pastel",
+      pane: "osm",
+    });
+
+    map.addLayer(basicLight);
+
+    const baseMaps = {
+      DiscreteColours: discreteAir,
+      LinearColours: linearAir,
+    };
+    const overlayMaps = {
+      TonerLite: tonerLite,
+      BasicLight: basicLight,
+      StreetsPastel: streetsPastel,
+    };
+
+    L.control.layers(baseMaps, null, { collapsed: false }).addTo(map);
+    L.control.layers(overlayMaps, null, { collapsed: false }).addTo(map);
   }
 });


### PR DESCRIPTION
We can now switch between:

- 3 Maptiler styles:

  - streets-v2-pastel
  - basic-v2-light and
  - toner-v2-lite

- the 2 CERC styles of colour gradation:

  - discrete
  - linear


![map_with_choices](https://github.com/user-attachments/assets/868adb9e-4652-4e4b-82cb-43be1768618c)


See screenshots of the 3 styles:

## streets-v2-pastel
![streets_v2_pastel](https://github.com/user-attachments/assets/26246927-023a-43ad-a54d-5568e41aabd7)


## basic-v2-light
![basic_v2_light](https://github.com/user-attachments/assets/68a2b9c9-d874-419f-a4ef-9bdaf260c799)


## toner-v2-lite
![toner-v2-lite](https://github.com/user-attachments/assets/8a729629-c275-4dcd-a240-5cb3abad6781)


## Customisation

Note that it's possible to customise the hue, lightness and saturation of MapTiler styles:

<img width="1223" alt="customising_a_maptiler_style" src="https://github.com/user-attachments/assets/fbee5996-7217-45a0-bb07-1c80f37ec163">

