### PR TITLE
Show daqi colour tiles as map footer

### DIFF
--- a/app/views/forecasts/_forecast_tabs.html.erb
+++ b/app/views/forecasts/_forecast_tabs.html.erb
@@ -14,4 +14,7 @@
   <%= render partial: "map_selector" %>
   <div id="map" class="map w-full bg-green-200 h-80" data-maptiler-api-key="<%= @maptiler_api_key %>">
   </div>
+  <div class="w-full h-10 bg-stone-700">
+    <%= render "shared/daqi_scale" %>
+  </div>
 </div>

--- a/app/views/shared/_daqi_scale.html.erb
+++ b/app/views/shared/_daqi_scale.html.erb
@@ -5,8 +5,8 @@
   <div class="py-2 daqi-level grow bg-yellow-300">4</div>
   <div class="py-2 daqi-level grow bg-amber-200">5</div>
   <div class="py-2 daqi-level grow bg-yellow-500">6</div>
-  <div class="py-2 daqi-level grow bg-orange-500">7</div>
-  <div class="py-2 daqi-level grow bg-red-500">8</div>
-  <div class="py-2 daqi-level grow bg-red-800">9</div>
-  <div class="py-2 daqi-level grow bg-stone-700">10</div>
+  <div class="py-2 daqi-level grow bg-orange-500 text-white">7</div>
+  <div class="py-2 daqi-level grow bg-red-500 text-white">8</div>
+  <div class="py-2 daqi-level grow bg-red-800 text-white">9</div>
+  <div class="py-2 daqi-level grow bg-stone-700 text-white">10</div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,4 @@
 <header class="bg-gray-50" >
-  <%= render "shared/daqi_scale" %>
   <div class="flex flex-row p-4" >
     <div class="heading bg-gray-50 grow" >
       <h1 class="text-4xl font-bold">


### PR DESCRIPTION
## Changes in this PR

According to the new designs, this moves the DAQI colour scale from the header to below the map.

## Screenshots of UI changes

### Before

![Screenshot 2024-11-07 at 11 21 23](https://github.com/user-attachments/assets/2e10c7df-2557-4a7b-a3d1-648222850595)

### After

![Screenshot 2024-11-07 at 11 21 00](https://github.com/user-attachments/assets/2ccf44d8-71bd-4291-9928-8b0d03e1d30d)

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
