### PR TITLE
Refactor toggling of prediction guidance to Stimulus

### DIFF
--- a/app/components/prediction_component.html.erb
+++ b/app/components/prediction_component.html.erb
@@ -1,24 +1,40 @@
-<div class="prediction py-4 <%= name_for_class %> <%= daqi_level_for_class %> border-b border-gray-400">
+<div
+  class="prediction py-4 <%= name_for_class %> <%= daqi_level_for_class %> border-b border-gray-400"
+  data-controller="prediction"
+>
   <div class="summary flex flex-row">
     <dt class="name w-1/2">
       <%= name_for_label %>
     </dt>
     <dd class="flex flex-row w-1/2 justify-between">
-    <div class="flex flex-row">
-      <div class=" -mt-1 daqi-indicator <%= daqi_level_for_class %> <%= daqi_indicator_colour %> text-2xl">●</div>
-      <div class=" daqi-label font-bold ml-1"><%= daqi_level_for_label %></div>
+      <div class="flex flex-row">
+        <div class=" -mt-1 daqi-indicator <%= daqi_level_for_class %> <%= daqi_indicator_colour %> text-2xl">●</div>
+        <div class=" daqi-label font-bold ml-1"><%= daqi_level_for_label %></div>
       </div>
-      <div class="control">
-        <button id="<%= name_for_class %>-show-guidance-button" class="<%= guidance_visible? ? "hidden" : "visible" %>">
+      <div
+        class="control"
+        data-action="click->prediction#toggleGuidance"
+        >
+        <button
+          class="<%= guidance_visible? ? "hidden" : "visible" %>"
+          data-prediction-target="showButton"
+        >
           <%= render partial: "shared/icons/chevron_down" %>
         </button>
-        <button id="<%= name_for_class %>-hide-guidance-button" class="<%= !guidance_visible? ? "hidden" : "visible" %>">
+        <button
+          class="<%= !guidance_visible? ? "hidden" : "visible" %>"
+          data-prediction-target="hideButton"
+        >
           <%= render partial: "shared/icons/chevron_up" %>
         </button>
       </div>
     </dd>
   </div>
-  <div id="<%= name_for_class %>-guidance" class="details <%= !guidance_visible? ? "hidden" : "visible" %> <%= details_panel_colour %> p-4 mt-2">
+  <div
+    id="<%= name_for_class %>-guidance"
+    class="details <%= !guidance_visible? ? "hidden" : "visible" %> <%= details_panel_colour %> p-4 mt-2"
+    data-prediction-target="guidance"
+  >
     <div class="daqi-value text-lg">
       <%= daqi_value_as_index %>
     </div>

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -42,39 +42,5 @@ document.addEventListener("DOMContentLoaded", function () {
       selectedPollutant.innerText = newSelectedPollutant;
       pollutantMenu.classList.toggle("hidden");
     });
-
-  const showUvGuidanceButton = document.getElementById(
-    "ultraviolet-rays-uv-show-guidance-button"
-  );
-  const hideUvGuidanceButton = document.getElementById(
-    "ultraviolet-rays-uv-hide-guidance-button"
-  );
-  const uvGuidance = document.getElementById("ultraviolet-rays-uv-guidance");
-
-  [showUvGuidanceButton, hideUvGuidanceButton].forEach((button) => {
-    button &&
-      button.addEventListener("click", function () {
-        showUvGuidanceButton.classList.toggle("hidden");
-        hideUvGuidanceButton.classList.toggle("hidden");
-        uvGuidance.classList.toggle("hidden");
-      });
-  });
-
-  const showPollenGuidanceButton = document.getElementById(
-    "pollen-show-guidance-button"
-  );
-  const hidePollenGuidanceButton = document.getElementById(
-    "pollen-hide-guidance-button"
-  );
-  const pollenGuidance = document.getElementById("pollen-guidance");
-
-  [showPollenGuidanceButton, hidePollenGuidanceButton].forEach((button) => {
-    button &&
-      button.addEventListener("click", function () {
-        showPollenGuidanceButton.classList.toggle("hidden");
-        hidePollenGuidanceButton.classList.toggle("hidden");
-        pollenGuidance.classList.toggle("hidden");
-      });
-  });
 });
 import "./controllers";

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application";
 
+import PredictionController from "./prediction_controller";
+application.register("prediction", PredictionController);
+
 import TabController from "./tab_controller";
 application.register("tab", TabController);

--- a/app/javascript/controllers/prediction_controller.js
+++ b/app/javascript/controllers/prediction_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class PredictionController extends Controller {
+  static targets = ["showButton", "hideButton", "guidance"];
+
+  toggleGuidance() {
+    this.showButtonTarget.classList.toggle("hidden");
+    this.hideButtonTarget.classList.toggle("hidden");
+    this.guidanceTarget.classList.toggle("hidden");
+  }
+}


### PR DESCRIPTION
We define a `PredictionController` on the scope of the whole "prediction wrapper" element. The *controller* has single *action*: `toggleGuidance` which acts on 3 *targets* within the prediction:

- `showGuidanceButton`: toggle visibility on the "show" button
- `hideGuidanceButton`: toggle visibility on the "hide" button
- `guidance`: toggle visibility on the guidance itself

This allows us to replace some custom event handlers in `application.js` with a modular and conventional approach, which should be more maintainable.

This little toggling behaviour is very similar to the initial example of using Stimulus in chapter 3 of Noel Rappin's book "Modern Front-End Development for Rails, Second Edition", which we recommend.

