### PR TITLE
Add debugging tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ tmp/
 !/app/assets/builds/.keep
 
 /node_modules
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development do
 end
 
 group :development, :test do
+  gem "binding_of_caller"
   gem "brakeman"
   gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ end
 
 group :test do
   gem "capybara", ">= 2.15"
+  gem "capybara-screenshot"
   gem "cuprite"
   gem "database_cleaner"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-screenshot (1.0.26)
+      capybara (>= 1.0, < 4)
+      launchy
     childprocess (5.1.0)
       logger (~> 1.5)
     climate_control (1.2.0)
@@ -455,6 +458,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 2.15)
+  capybara-screenshot
   climate_control
   cssbundling-rails (~> 1.4)
   cuprite

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
       rouge (>= 1.0.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     brakeman (6.2.2)
@@ -125,6 +127,7 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.4)
+    debug_inspector (1.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dotenv (3.1.4)
@@ -441,10 +444,12 @@ PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
   x86_64-darwin-21
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
   better_errors
+  binding_of_caller
   bootsnap (>= 1.1.0)
   brakeman
   bullet

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,6 +3,10 @@
 Dir[Rails.root.join("spec", "feature_steps", "**", "*.rb")].sort.each { |f| require f }
 
 require "capybara/cuprite"
+require "capybara/rspec"
+require "capybara-screenshot/rspec"
+
+Capybara::Screenshot.prune_strategy = {keep: 20}
 Capybara.default_max_wait_time = 5
 Capybara.disable_animation = true
 Capybara.javascript_driver = :cuprite


### PR DESCRIPTION
## Changes in this PR

This PR adds a couple of useful debugging tools:
- `binding-of-caller` which adds a console to error pages served by Better Errors
- `capybara-screenshot` which takes screenshot of failing browser tests to assist with debugging