### PR TITLE
Run CI on all branches, not just main and develop

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,9 +3,6 @@
 on:
   pull_request:
   push:
-    branches:
-      - main
-      - develop
 
 jobs:
   test:


### PR DESCRIPTION
## Context

Currently when you push to a branch no tests will be run until you open a PR.

## Changes in this PR

This PR makes CI run on all branches. This means we can have it running while writing the PR so that it's done by the time the PR is opened.

The cost is that with multiple pushes we'll be using additional minutes on our GitHub Actions usage, but this is of minimal concern.