### PR TITLE
DRY up CERC API client

### DIFF
--- a/app/models/cerc_api_client.rb
+++ b/app/models/cerc_api_client.rb
@@ -1,34 +1,16 @@
-require "httparty"
-
 class CercApiClient
-  include HTTParty
+  class << self
+    def latest_forecasts(zone = nil)
+      base_url = ENV.fetch("CERC_API_HOST_URL")
 
-  def self.fetch_data(zone)
-    base_url = ENV.fetch("CERC_API_HOST_URL")
+      query = {
+        "from" => Date.today,
+        "numdays" => 3,
+        "zone" => zone,
+        "key" => ENV.fetch("CERC_API_KEY")
+      }.compact
 
-    query = {
-      "from" => Date.today,
-      "numdays" => 3,
-      "zone" => zone,
-      "key" => ENV.fetch("CERC_API_KEY")
-    }
-
-    HTTParty.get("#{base_url}/getforecast/all", query: query)
-  end
-
-  def self.forecasts_for(zone)
-    ForecastFactory.build(cerc_forecasts: fetch_data(zone))
-  end
-
-  def self.latest_forecasts
-    base_url = ENV.fetch("CERC_API_HOST_URL")
-
-    query = {
-      "from" => Date.today,
-      "numdays" => 3,
-      "key" => ENV.fetch("CERC_API_KEY")
-    }
-
-    HTTParty.get("#{base_url}/getforecast/all", query: query)
+      HTTParty.get("#{base_url}/getforecast/all", query: query)
+    end
   end
 end

--- a/spec/models/cerc_api_client_spec.rb
+++ b/spec/models/cerc_api_client_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe CercApiClient do
     allow(ENV).to receive(:fetch).with("CERC_API_KEY").and_return("ABC123")
   end
 
-  describe "#fetch_data" do
+  describe "#latest_forecasts" do
     it "makes a request to the API with the expected parameters" do
       allow(HTTParty).to receive(:get)
 
-      CercApiClient.fetch_data("North London")
+      CercApiClient.latest_forecasts("North London")
       expect(HTTParty).to have_received(:get).with("https://example.com/getforecast/all", {
         query: {
           "zone" => "North London",
@@ -18,57 +18,46 @@ RSpec.describe CercApiClient do
         }
       })
     end
-  end
 
-  describe "#forecasts_for" do
-    it "calls the ForecastFactory's build method with data from fetch_data" do
-      forecast_data = {"some forecast key": "some forecast data"}
-      allow(CercApiClient).to receive(:fetch_data).and_return(forecast_data)
-      allow(ForecastFactory).to receive(:build)
-
-      CercApiClient.forecasts_for("North London")
-      expect(ForecastFactory).to have_received(:build).with(cerc_forecasts: forecast_data)
-    end
-  end
-
-  describe "::latest_forecasts" do
-    let(:forecasts_for_all_zones) do
-      {
-        "forecastdate" => "02-10-2024 15:16",
-        "timestamp" => 1727882190223.2139,
-        "zones" => [
-          {
-            "forecasts" => [{}, {}, {}],
-            "zone_id" => 1,
-            "zone_name" => "Barking and Dagenham",
-            "zone_type" => 1
-          },
-          {
-            "forecasts" => [{}, {}, {}],
-            "zone_id" => 2,
-            "zone_name" => "Barnet",
-            "zone_type" => 1
-          }
-        ]
-      }
-    end
-
-    before { allow(HTTParty).to receive(:get).and_return(forecasts_for_all_zones) }
-
-    it "asks the CERC API for 3 days worth of forecasts for each zone" do
-      CercApiClient.latest_forecasts
-
-      expect(HTTParty).to have_received(:get).with("https://example.com/getforecast/all", {
-        query: {
-          "key" => "ABC123",
-          "numdays" => 3,
-          "from" => Date.today
+    describe "for all zones" do
+      let(:forecasts_for_all_zones) do
+        {
+          "forecastdate" => "02-10-2024 15:16",
+          "timestamp" => 1727882190223.2139,
+          "zones" => [
+            {
+              "forecasts" => [{}, {}, {}],
+              "zone_id" => 1,
+              "zone_name" => "Barking and Dagenham",
+              "zone_type" => 1
+            },
+            {
+              "forecasts" => [{}, {}, {}],
+              "zone_id" => 2,
+              "zone_name" => "Barnet",
+              "zone_type" => 1
+            }
+          ]
         }
-      })
-    end
+      end
 
-    it "returns 3 daily forecasts for each zone" do
-      expect(CercApiClient.latest_forecasts).to eq(forecasts_for_all_zones)
+      before { allow(HTTParty).to receive(:get).and_return(forecasts_for_all_zones) }
+
+      it "asks the CERC API for 3 days worth of forecasts for each zone" do
+        CercApiClient.latest_forecasts
+
+        expect(HTTParty).to have_received(:get).with("https://example.com/getforecast/all", {
+          query: {
+            "key" => "ABC123",
+            "numdays" => 3,
+            "from" => Date.today
+          }
+        })
+      end
+
+      it "returns 3 daily forecasts for each zone" do
+        expect(CercApiClient.latest_forecasts).to eq(forecasts_for_all_zones)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context
Currently the CERC API client class has a lot of duplication, and includes a method `.forecasts_for` that isn't ever used.

## Changes in this PR
This PR DRYs up the class and its test.