### PR TITLE
Only show the pollen prediction when it is not -999

### DIFF
--- a/app/models/pollen_prediction.rb
+++ b/app/models/pollen_prediction.rb
@@ -15,6 +15,10 @@ class PollenPrediction
     I18n.t("prediction.guidance.pollen.#{daqi_level}")
   end
 
+  def valid?
+    value != -999
+  end
+
   # :nocov:
   def inspect
     "#<#{self.class.name} @value=#{value}>"

--- a/app/views/forecasts/_predictions.html.erb
+++ b/app/views/forecasts/_predictions.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "day_predictions" do %>
   <dl class="predictions p-4">
     <%= render(PredictionComponent.new(prediction: forecast.uv)) %>
-    <%= render(PredictionComponent.new(prediction: forecast.pollen)) %>
+    <%= render(PredictionComponent.new(prediction: forecast.pollen)) if forecast.pollen.valid? %>
     <%= render "temperature_prediction", prediction: forecast.temperature %>
   </dl>
 <% end %>

--- a/spec/features/visitors/view_forecasts_spec.rb
+++ b/spec/features/visitors/view_forecasts_spec.rb
@@ -140,5 +140,41 @@ RSpec.feature "Forecasts page", feature: true do
         expect_prediction(category: :temperature, level: :high)
       end
     end
+
+    describe "Viewing pollen prediction" do
+      context "when the pollen level is a positive number" do
+        before do
+          forecasts = [
+            Fixtures::API.zone_forecast(day: :today),
+            Fixtures::API.zone_forecast(day: :tomorrow),
+            Fixtures::API.zone_forecast(day: :day_after_tomorrow)
+          ]
+          stub_cerc_api_with(forecasts)
+        end
+
+        it "shows the pollen prediction" do
+          view_forecasts
+
+          expect(page).to have_css(".pollen")
+        end
+      end
+
+      context "when the pollen level is -999" do
+        before do
+          forecasts = [
+            Fixtures::API.zone_forecast(day: :today).merge("pollen" => -999),
+            Fixtures::API.zone_forecast(day: :tomorrow),
+            Fixtures::API.zone_forecast(day: :day_after_tomorrow)
+          ]
+          stub_cerc_api_with(forecasts)
+        end
+
+        it "does not show the pollen prediction" do
+          view_forecasts
+
+          expect(page).not_to have_css(".pollen")
+        end
+      end
+    end
   end
 end

--- a/spec/models/pollen_prediction_spec.rb
+++ b/spec/models/pollen_prediction_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe PollenPrediction do
+  describe "#valid" do
+    let(:prediction) { FactoryBot.build(:pollen_prediction, value: value) }
+
+    context "when the value is -999" do
+      let(:value) { -999 }
+      it "returns false" do
+        expect(prediction.valid?).to eq(false)
+      end
+    end
+
+    context "when the value is not -999" do
+      let(:value) { 1 }
+      it "returns true" do
+        expect(prediction.valid?).to eq(true)
+      end
+    end
+  end
+
+  describe "#guidance" do
+    let(:prediction) { FactoryBot.build(:pollen_prediction, value: value) }
+    let(:value) { 1 }
+
+    it "returns the guidance for the level" do
+      expect(prediction.guidance).to eq(I18n.t("prediction.guidance.pollen.low"))
+    end
+  end
+end


### PR DESCRIPTION
## Context
-999 is a special value returned by the CERC API when there is no pollen prediction (outside of pollen season). Currently we are displaying that to the user when we shouldn't be.

## Changes in this PR
This PR adds a validity check before displaying the prediction to make sure that it is a normal value, and will hide it if it is not.