### PR TITLE
Add ability to change pollutant type

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -24,23 +24,5 @@ document.addEventListener("DOMContentLoaded", function () {
       selectedZone.innerText = newSelectedZone;
       locationList.classList.toggle("hidden");
     });
-
-  const pollutantSelectorButton = document.getElementById(
-    "pollutant-selector-button"
-  );
-  const pollutantMenu = document.getElementById("pollutant-selector-menu");
-
-  pollutantSelectorButton &&
-    pollutantSelectorButton.addEventListener("click", function () {
-      pollutantMenu.classList.toggle("hidden");
-    });
-
-  pollutantMenu &&
-    pollutantMenu.addEventListener("click", function (e) {
-      const newSelectedPollutant = e.target.innerText;
-      const selectedPollutant = document.getElementById("selected-pollutant");
-      selectedPollutant.innerText = newSelectedPollutant;
-      pollutantMenu.classList.toggle("hidden");
-    });
 });
 import "./controllers";

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -4,6 +4,8 @@ import "@maptiler/leaflet-maptilersdk";
 import * as zones from "../zone_boundaries/zone-boundaries";
 
 export default class MapController extends Controller {
+  static targets = ["map", "pollutantSelector"];
+
   layers = {};
   controls = {};
   defaultMapSettings = {
@@ -48,9 +50,7 @@ export default class MapController extends Controller {
   }
 
   streetMaps() {
-    const maptilerApiKey = document
-      .getElementById("map")
-      .getAttribute("data-maptiler-api-key");
+    const maptilerApiKey = this.mapTarget.dataset.maptilerApiKey;
     const tonerLite = new L.MaptilerLayer({
       apiKey: maptilerApiKey,
       style: "toner-v2-lite",
@@ -189,7 +189,7 @@ export default class MapController extends Controller {
   }
 
   updateMap() {
-    const pollutant = document.querySelector("select#pollutant").value;
+    const pollutant = this.pollutantSelectorTarget.value;
     const newSettings = { pollutant: pollutant };
     this.settings = Object.assign({}, this.defaultMapSettings, newSettings);
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -4,6 +4,8 @@ import "@maptiler/leaflet-maptilersdk";
 import * as zones from "../zone_boundaries/zone-boundaries";
 
 export default class MapController extends Controller {
+  layers = {};
+  controls = {};
   defaultMapSettings = {
     pollutant: "Total",
     date: new Date().toJSON().slice(0, 10),
@@ -75,13 +77,16 @@ export default class MapController extends Controller {
       this.settings.pollutant,
       this.settings.date
     );
-    this.map.addLayer(discreteAir);
+    this.layers.pollution = discreteAir;
+    this.map.addLayer(this.layers.pollution);
 
     const pollutionMaps = {
       DiscreteColours: discreteAir,
       LinearColours: linearAir,
     };
-    L.control.layers(pollutionMaps, null, { collapsed: false }).addTo(this.map);
+    this.controls.pollution = L.control
+      .layers(pollutionMaps, null, { collapsed: false })
+      .addTo(this.map);
   }
 
   pollutionLayers(pollutant, date) {
@@ -181,5 +186,19 @@ export default class MapController extends Controller {
         }
       });
     });
+  }
+
+  updateMap() {
+    const pollutant = document.querySelector("select#pollutant").value;
+    const newSettings = { pollutant: pollutant };
+    this.settings = Object.assign({}, this.defaultMapSettings, newSettings);
+
+    this.updatePollutionLayer();
+  }
+
+  updatePollutionLayer() {
+    this.map.removeControl(this.controls.pollution);
+    this.map.removeLayer(this.layers.pollution);
+    this.addPollutionLayer();
   }
 }

--- a/app/views/forecasts/_map.html.erb
+++ b/app/views/forecasts/_map.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="map">
   <%= render partial: "pollutant_selector" %>
-  <div id="map" class="map w-full h-80" data-maptiler-api-key="<%= @maptiler_api_key %>"></div>
+  <div id="map" class="map w-full h-80" data-maptiler-api-key="<%= @maptiler_api_key %>" data-map-target="map"></div>
   <div class="w-full h-10">
     <%= render "shared/daqi_scale" %>
   </div>

--- a/app/views/forecasts/_pollutant_selector.html.erb
+++ b/app/views/forecasts/_pollutant_selector.html.erb
@@ -1,11 +1,15 @@
 <div class="relative inline-block w-full text-left p-4">
   <%= form_tag do %>
-    <%= select_tag :pollutant, options_for_select({
+    <%= select_tag :pollutant, 
+    options_for_select({
       "All pollutants" => 'Total',
       "Nitrogen Dioxide" => 'NO2',
       "Particles < 2.5µm" => 'PM25',
       "Particles < 10µm" => 'PM10',
       "Ozone" => 'O3',
-    }),  data:{ action: "map#updateMap" }, class: "inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+    }),
+    data:{ action: "map#updateMap", "map-target": "pollutantSelector" },
+    class: "inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+    %>
   <% end %>
 </div>

--- a/app/views/forecasts/_pollutant_selector.html.erb
+++ b/app/views/forecasts/_pollutant_selector.html.erb
@@ -1,35 +1,5 @@
 <div class="relative inline-block w-full text-left p-4">
-  <div>
-    <button id="pollutant-selector-button" type="button" class="inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" id="menu-button" aria-expanded="true" aria-haspopup="true">
-      <div class="grow text-left" id="selected-pollutant">
-        All pollutants
-      </div>
-      <svg class="-mr-1 h-5 w-5 text-right text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-        <path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
-      </svg>
-    </button>
-  </div>
-  <!--
-    SET TO HIDDEN FOR NOW UNTIL WE IMPLEMENT A JS HANDLER
-    FOR SELECT LISTS
-
-    Dropdown menu, show/hide based on menu state.
-
-    Entering: "transition ease-out duration-100"
-      From: "transform opacity-0 scale-95"
-      To: "transform opacity-100 scale-100"
-    Leaving: "transition ease-in duration-75"
-      From: "transform opacity-100 scale-100"
-      To: "transform opacity-0 scale-95"
-  -->
-  <div id="pollutant-selector-menu" class="relative right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none hidden" role="menu" aria-orientation="vertical" aria-labelledby="menu-button" tabindex="-1">
-    <ul class="py-1" role="none">
-      <!-- Active: "bg-gray-100 text-gray-900", Not Active: "text-gray-700" -->
-      <li class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="menu-item-0">All pollutants</li>
-      <li class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="menu-item-1">Nitrogen Dioxide</li>
-      <li class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="menu-item-2">Particles &lt; 2.5µm</li>
-      <li class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="menu-item-3">Particles &lt; 10µm</li>
-      <li class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="menu-item-4">Ozone</li>
-    </ul>
-  </div>
+  <%= form_tag do %>
+    <%= select_tag :pollutant, options_for_select(["All pollutants", "Nitrogen Dioxide", "Particles < 2.5µm", "Particles < 10µm", "Ozone"]), class: "inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+  <% end %>
 </div>

--- a/app/views/forecasts/_pollutant_selector.html.erb
+++ b/app/views/forecasts/_pollutant_selector.html.erb
@@ -1,5 +1,11 @@
 <div class="relative inline-block w-full text-left p-4">
   <%= form_tag do %>
-    <%= select_tag :pollutant, options_for_select(["All pollutants", "Nitrogen Dioxide", "Particles < 2.5µm", "Particles < 10µm", "Ozone"]), class: "inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+    <%= select_tag :pollutant, options_for_select({
+      "All pollutants" => 'Total',
+      "Nitrogen Dioxide" => 'NO2',
+      "Particles < 2.5µm" => 'PM25',
+      "Particles < 10µm" => 'PM10',
+      "Ozone" => 'O3',
+    }),  data:{ action: "map#updateMap" }, class: "inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
   <% end %>
 </div>


### PR DESCRIPTION
## Context
The user should be able to switch between different pollutant types. Currently there is a custom-made pollution selector that is not wired up to the map.

Trello: https://trello.com/c/nPGXxiNt/111-allow-user-to-switch-between-different-pollution-types

## Changes in this PR
This PR changes the pollution selector to be a native `<select>` element to simplify the code and improve accessibility. Using the selector causes the map to be updated. 

## Screenshots of UI changes

### Before
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/69273f68-3586-4fc8-ae94-354a956064d3">


### After
<img width="1221" alt="image" src="https://github.com/user-attachments/assets/11654935-89ae-4479-bcdd-06f2b433c092">