### PR TITLE
Make map update when day tab changes

### DIFF
--- a/app/components/day_tab_component.html.erb
+++ b/app/components/day_tab_component.html.erb
@@ -4,12 +4,13 @@
     controller: "tab",
     "tab-active-class": "active",
     "tab-inactive-class": "inactive",
-    "tab-target": "dayPrediction"
+    "tab-target": "dayPrediction",
+    "map-target": "daySelector",
   } do
   %>
 <%= link_to update_forecast_path(day: @day, format: :turbo_stream),
       data: {
-        action: "click->tab#switch_tab"
+        action: "click->tab#switch_tab click->map#updateMap",
     } do %>
   <div class="day" data-tab-target="day">
     <%= @forecast.date == Date.today ? 'Today' : @forecast.date.strftime('%A') %>

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -4,7 +4,7 @@ import "@maptiler/leaflet-maptilersdk";
 import * as zones from "../zone_boundaries/zone-boundaries";
 
 export default class MapController extends Controller {
-  static targets = ["map", "pollutantSelector"];
+  static targets = ["map", "pollutantSelector", "daySelector"];
 
   layers = {};
   controls = {};
@@ -190,7 +190,8 @@ export default class MapController extends Controller {
 
   updateMap() {
     const pollutant = this.pollutantSelectorTarget.value;
-    const newSettings = { pollutant: pollutant };
+    const date = this.daySelector.dataset.date;
+    const newSettings = { pollutant: pollutant, date: date };
     this.settings = Object.assign({}, this.defaultMapSettings, newSettings);
 
     this.updatePollutionLayer();

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -1,8 +1,10 @@
-<%= render partial: "forecasts/location" %>
-<%= render partial: "forecasts/forecast_tabs", cerc_forecasts: @forecasts %>
-<%= render partial: "forecasts/map" %>
-<%= render partial: "forecasts/predictions", locals: { forecast: @forecasts.first } %>
-<%= render partial: "sharing" %>
+<div data-controller="map">
+  <%= render partial: "forecasts/location" %>
+  <%= render partial: "forecasts/forecast_tabs", cerc_forecasts: @forecasts %>
+  <%= render partial: "forecasts/map" %>
+  <%= render partial: "forecasts/predictions", locals: { forecast: @forecasts.first } %>
+  <%= render partial: "sharing" %>
+</div>
 <%= render partial: "learning" %>
 <%= render partial: "subscribe" %>
 <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>


### PR DESCRIPTION
## Context
Currently we have tabs for today, tomorrow, and the day after, but click these does not change the map. 

Trello: https://trello.com/c/kDEQKX4p/105-load-map-air-quality-map-overlays-for-the-selected-day

## Changes in this PR
This PR adds functionality so that when the tabs change the map.

To make the controller action work, we need to increase the scope of the controller from just the map element to the whole forecast section.