### PR TITLE
Fix map double connect

### DIFF
--- a/app/views/forecasts/_map.html.erb
+++ b/app/views/forecasts/_map.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="map">
+<div>
   <%= render partial: "pollutant_selector" %>
   <div id="map" class="map w-full h-80" data-maptiler-api-key="<%= @maptiler_api_key %>" data-map-target="map"></div>
   <div class="w-full h-10">


### PR DESCRIPTION
## Context
At some point in the last few PRs we ended up with the map controller being attached to two elements which causes it to connect and attempt to initialize the map twice. This results in an error in the console.

## Changes in this PR
This change fixes the problem.