### PR TITLE
Drive page content with URL parameters

### DIFF
--- a/app/components/day_tab_component.html.erb
+++ b/app/components/day_tab_component.html.erb
@@ -1,16 +1,11 @@
 <%= tag.div class: "tab py-4 flex-1 #{@day} mx-2 px-1 text-center #{classes}",
   data: {
     date: @forecast.date.to_s,
-    controller: "tab",
-    "tab-active-class": "active",
-    "tab-inactive-class": "inactive",
+    day: @day,
     "tab-target": "dayPrediction",
+    action: "click->tab#changeTab",
   } do
   %>
-<%= link_to update_forecast_path(day: @day, format: :turbo_stream),
-      data: {
-        action: "click->tab#switch_tab click->map#updateMap",
-    } do %>
   <div class="day" data-tab-target="day">
     <%= @forecast.date == Date.today ? 'Today' : @forecast.date.strftime('%A') %>
   </div>
@@ -29,5 +24,4 @@
   <div class="daqi-value font-normal" data-tab-target="daqiValue">
     Index <%= @forecast.air_pollution.value %>/10
   </div>
-<% end %>
 <% end %>

--- a/app/components/day_tab_component.rb
+++ b/app/components/day_tab_component.rb
@@ -1,7 +1,8 @@
 class DayTabComponent < ViewComponent::Base
-  def initialize(forecast:, day:)
+  def initialize(forecast:, day:, active: false)
     @forecast = forecast
     @day = day
+    @active = active
   end
 
   TAG_COLOURS = {
@@ -22,7 +23,7 @@ class DayTabComponent < ViewComponent::Base
   end
 
   def classes
-    if @day == :today
+    if @active
       "active daqi-level-#{@forecast.air_pollution.value}-today"
     else
       "inactive after-today"

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -2,7 +2,9 @@ class ForecastsController < ApplicationController
   def show
     @maptiler_api_key = ENV.fetch("MAPTILER_API_KEY")
     @zone = zone
+    @day = params.fetch("day", "today")
     @forecasts = CercForecastService.latest_forecasts_for(zone).data
+    @day_forecast = forecast_for_day(@day, @forecasts)
   end
 
   def update

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -7,17 +7,6 @@ class ForecastsController < ApplicationController
     @day_forecast = forecast_for_day(@day, @forecasts)
   end
 
-  def update
-    @maptiler_api_key = ENV.fetch("MAPTILER_API_KEY")
-    forecasts = CercForecastService.latest_forecasts_for(zone).data
-
-    @day_forecast = forecast_for_day(params.fetch("day"), forecasts)
-
-    respond_to do |format|
-      format.turbo_stream
-    end
-  end
-
   private
 
   def forecast_for_day(day, forecasts)

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -19,7 +19,7 @@ export default class MapController extends Controller {
       .getAttribute("data-maptiler-api-key"),
   };
 
-  connect() {
+  mapTargetConnected() {
     this.updateSettings();
     this.createMap();
   }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -20,8 +20,15 @@ export default class MapController extends Controller {
   };
 
   connect() {
-    this.settings = this.defaultMapSettings;
+    this.updateSettings();
     this.createMap();
+  }
+
+  updateSettings() {
+    const pollutant = this.pollutantSelectorTarget.value;
+    const date = this.daySelectorTarget.querySelector(".active").dataset.date;
+    const newSettings = { pollutant: pollutant, date: date };
+    this.settings = Object.assign({}, this.defaultMapSettings, newSettings);
   }
 
   createMap() {
@@ -208,11 +215,7 @@ export default class MapController extends Controller {
   }
 
   updateMap() {
-    const pollutant = this.pollutantSelectorTarget.value;
-    const date = this.daySelectorTarget.querySelector(".active").dataset.date;
-    const newSettings = { pollutant: pollutant, date: date };
-    this.settings = Object.assign({}, this.defaultMapSettings, newSettings);
-
+    this.updateSettings();
     this.updatePollutionLayer();
   }
 

--- a/app/javascript/controllers/prediction_controller.js
+++ b/app/javascript/controllers/prediction_controller.js
@@ -1,11 +1,23 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class PredictionController extends Controller {
-  static targets = ["showButton", "hideButton", "guidance"];
+  static targets = ["showButton", "hideButton", "guidance", "zoneSelector"];
 
   toggleGuidance() {
     this.showButtonTarget.classList.toggle("hidden");
     this.hideButtonTarget.classList.toggle("hidden");
     this.guidanceTarget.classList.toggle("hidden");
+  }
+
+  changeZone() {
+    const selectedZone = this.zoneSelectorTarget.value;
+
+    // Update the URL with the new zone
+    const url = new URL(window.location.href);
+    url.searchParams.set("zone", selectedZone);
+    window.history.pushState({}, "", url);
+
+    // Submit the form to reload the turbo frame
+    this.zoneSelectorTarget.form.requestSubmit();
   }
 }

--- a/app/javascript/controllers/tab_controller.js
+++ b/app/javascript/controllers/tab_controller.js
@@ -1,59 +1,23 @@
 import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="tab"
-export default class extends Controller {
-  static classes = ["active", "inactive"];
-  static targets = ["dayPrediction", "day", "daqiValue"];
+export default class TabController extends Controller {
+  static targets = ["daySelector"];
 
   connect() {}
 
-  switch_tab() {
-    this.makeAllTabsInactive();
-    this.removeDaqiAlertClasses();
+  changeTab(event) {
+    const selectedDay = event.currentTarget.dataset.day;
 
-    this.addAlertClassIfNotTodayAndHasAirQualityAlert();
-    this.dayPredictionTarget.classList.toggle(this.activeClass);
-    this.dayPredictionTarget.classList.toggle(this.inactiveClass);
-  }
+    // Add the new date to the URL
+    const url = new URL(window.location.href);
+    url.searchParams.set("day", selectedDay);
+    window.history.pushState({}, "", url);
 
-  makeAllTabsInactive() {
-    document.querySelectorAll(".tabs .tab").forEach((el) => {
-      el.classList.remove(this.activeClass);
-      el.classList.add(this.inactiveClass);
-    });
-  }
+    // Update contents of daySelector
+    this.daySelectorTarget.value = selectedDay;
 
-  addAlertClassIfNotTodayAndHasAirQualityAlert() {
-    const daqiValue = this.getDaqiValue();
-    if (this.dayTarget.innerText !== "Today" && daqiValue > 3) {
-      this.addDaqiAlertClass();
-    }
-  }
-
-  addDaqiAlertClass() {
-    const daqiValue = this.getDaqiValue();
-    this.dayPredictionTarget.classList.add(
-      `daqi-alert-after-today-selected-level-${daqiValue}`
-    );
-  }
-
-  removeDaqiAlertClasses() {
-    document.querySelectorAll(".tabs .tab").forEach((el) => {
-      const daqiAlertClassRegex = new RegExp(
-        "daqi-alert-after-today-selected-level-(\\d{1,2})"
-      );
-
-      const fullClassName = Array.from(el.classList).find((className) =>
-        className.match(daqiAlertClassRegex)
-      );
-
-      if (fullClassName) {
-        el.classList.remove(fullClassName);
-      }
-    });
-  }
-
-  getDaqiValue() {
-    return this.daqiValueTarget.innerText.split("/")[0].split(" ")[1];
+    // Submit the form to reload the turbo frame
+    this.daySelectorTarget.form.requestSubmit();
   }
 }

--- a/app/views/forecasts/_alert_guidance.html.erb
+++ b/app/views/forecasts/_alert_guidance.html.erb
@@ -1,12 +1,10 @@
-<%= turbo_frame_tag "alert_guidance" do %>
-  <% if air_pollution_prediction.air_quality_alert %>
-    <div class="alert-guidance bg-<%= air_pollution_prediction.air_quality_alert.daqi_label.parameterize %>-alert-guidance-panel m-5 p-10">
-      <p class="font-semibold mb-4">
-        <%= t("air_quality_alert.#{air_pollution_prediction.air_quality_alert.daqi_level}.guidance.title") %>
-      </p>
-      <div class="text-xs">
-        <%= t("air_quality_alert.#{air_pollution_prediction.air_quality_alert.daqi_level}.guidance.detail_html") %>
-      </div>
+<% if air_pollution_prediction.air_quality_alert %>
+  <div class="alert-guidance bg-<%= air_pollution_prediction.air_quality_alert.daqi_label.parameterize %>-alert-guidance-panel m-5 p-10">
+    <p class="font-semibold mb-4">
+      <%= t("air_quality_alert.#{air_pollution_prediction.air_quality_alert.daqi_level}.guidance.title") %>
+    </p>
+    <div class="text-xs">
+      <%= t("air_quality_alert.#{air_pollution_prediction.air_quality_alert.daqi_level}.guidance.detail_html") %>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/forecasts/_forecast_tabs.html.erb
+++ b/app/views/forecasts/_forecast_tabs.html.erb
@@ -7,9 +7,9 @@
     data-turbo-prefetch="false"
     data-map-target="daySelector"
     >
-    <%= render(DayTabComponent.new(forecast: @forecasts.first, day: :today)) %>
-    <%= render(DayTabComponent.new(forecast: @forecasts.second, day: :tomorrow)) %>
-    <%= render(DayTabComponent.new(forecast: @forecasts.third, day: :day_after_tomorrow)) %>
+    <%= render(DayTabComponent.new(forecast: @forecasts.first, day: 'today', active: @day == 'today')) %>
+    <%= render(DayTabComponent.new(forecast: @forecasts.second, day: 'tomorrow', active: @day == 'tomorrow')) %>
+    <%= render(DayTabComponent.new(forecast: @forecasts.third, day: 'day_after_tomorrow', active: @day == 'day_after_tomorrow')) %>
   </div>
-  <%= render partial: "alert_guidance", locals: {air_pollution_prediction: @forecasts.first} %>
+  <%= render partial: "alert_guidance", locals: {air_pollution_prediction: @day_forecast} %>
 </div>

--- a/app/views/forecasts/_location_selector.html.erb
+++ b/app/views/forecasts/_location_selector.html.erb
@@ -5,5 +5,6 @@
     class: "inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50",
     data: { controller: "prediction", "prediction-target": "zoneSelector", action: "change->prediction#changeZone" }
     %>
+    <%= hidden_field_tag :day, @day, data: { "tab-target": "daySelector" } %>
   <% end %>
 </div>

--- a/app/views/forecasts/_location_selector.html.erb
+++ b/app/views/forecasts/_location_selector.html.erb
@@ -2,7 +2,8 @@
   <%= form_tag(false, method: :get) do %>
     <%= select_tag :zone, 
     options_for_select(Zone.all.order(:name).map(&:name), @zone.name),
-    class: "inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+    class: "inline-flex flex-row w-full justify-left gap-x-1.5 rounded-md bg-white px-3 py-2 text-base font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50",
+    data: { controller: "prediction", "prediction-target": "zoneSelector", action: "change->prediction#changeZone" }
     %>
   <% end %>
 </div>

--- a/app/views/forecasts/_predictions.html.erb
+++ b/app/views/forecasts/_predictions.html.erb
@@ -1,7 +1,5 @@
-<%= turbo_frame_tag "day_predictions" do %>
-  <dl class="predictions p-4">
-    <%= render(PredictionComponent.new(prediction: forecast.uv)) %>
-    <%= render(PredictionComponent.new(prediction: forecast.pollen)) if forecast.pollen.valid? %>
-    <%= render "temperature_prediction", prediction: forecast.temperature %>
-  </dl>
-<% end %>
+<dl class="predictions p-4">
+  <%= render(PredictionComponent.new(prediction: forecast.uv)) %>
+  <%= render(PredictionComponent.new(prediction: forecast.pollen)) if forecast.pollen.valid? %>
+  <%= render "temperature_prediction", prediction: forecast.temperature %>
+</dl>

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -4,12 +4,12 @@
   </h2>
 </div>
 
-<div data-controller="map">
+<turbo-frame id="forecasts" data-controller="map tab">
   <%= render partial: "forecasts/location" %>
   <%= render partial: "forecasts/forecast_tabs", cerc_forecasts: @forecasts %>
   <%= render partial: "forecasts/map" %>
   <%= render partial: "forecasts/predictions", locals: { forecast: @day_forecast } %>
   <%= render partial: "sharing" %>
-</div>
+</turbo-frame>
 <%= render partial: "learning" %>
 <%= render partial: "subscribe" %>

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -8,7 +8,7 @@
   <%= render partial: "forecasts/location" %>
   <%= render partial: "forecasts/forecast_tabs", cerc_forecasts: @forecasts %>
   <%= render partial: "forecasts/map" %>
-  <%= render partial: "forecasts/predictions", locals: { forecast: @forecasts.first } %>
+  <%= render partial: "forecasts/predictions", locals: { forecast: @day_forecast } %>
   <%= render partial: "sharing" %>
 </div>
 <%= render partial: "learning" %>

--- a/app/views/forecasts/update.turbo_stream.erb
+++ b/app/views/forecasts/update.turbo_stream.erb
@@ -1,2 +1,0 @@
-<%= turbo_stream.replace("day_predictions", partial: "predictions", locals: {forecast: @day_forecast}) %>
-<%= turbo_stream.replace("alert_guidance", partial: "alert_guidance", locals: {air_pollution_prediction: @day_forecast}) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
   get "map", to: "map#show"
 
   get :forecast, to: "forecasts#show"
-  get :update_forecast, to: "forecasts#update"
 
   get :health_advice, to: "pages#health_advice"
   get :about, to: "pages#about"

--- a/spec/components/day_tab_component_spec.rb
+++ b/spec/components/day_tab_component_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe DayTabComponent, type: :component do
   describe "classes" do
     context "when the day is today" do
       let(:component) {
-        DayTabComponent.new(forecast: FactoryBot.build(:forecast, air_pollution_level: 1), day: :today)
+        DayTabComponent.new(forecast: FactoryBot.build(:forecast, air_pollution_level: 1), day: :today, active: true)
       }
 
       it "returns the classes for today's tab" do

--- a/spec/controllers/forecasts_controller_spec.rb
+++ b/spec/controllers/forecasts_controller_spec.rb
@@ -39,17 +39,15 @@ RSpec.describe ForecastsController do
 
       expect(response).to render_template("show")
     end
-  end
 
-  describe "GET :update" do
     context "when a recognised _day_ parameter is received" do
       it "renders the turbo update template" do
         allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
 
-        get :update, params: {day: :today}, format: :turbo_stream
+        get :show, params: {day: :today}
 
         expect(CercForecastService).to have_received(:latest_forecasts_for).with(southwark)
-        expect(response).to render_template("forecasts/update")
+        expect(response).to render_template("show")
       end
     end
 
@@ -58,7 +56,7 @@ RSpec.describe ForecastsController do
         allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
 
         expect {
-          get :update, params: {day: :yesterday}
+          get :show, params: {day: :yesterday}
         }.to raise_error(ArgumentError, "Invalid day: yesterday")
       end
     end

--- a/spec/features/visitors/view_air_quality_alerts_spec.rb
+++ b/spec/features/visitors/view_air_quality_alerts_spec.rb
@@ -45,8 +45,8 @@ RSpec.feature "Air quality alerts", feature: true do
       within(".alert-guidance") do
         expect_to_see_guidance_for(:moderate)
       end
-      expect(page).to have_css(".tab.tomorrow.daqi-alert-after-today-selected-level-4")
-      expect(page).not_to have_css(".tab.day_after_tomorrow.daqi-alert-after-today-selected-level-10")
+      expect(page).to have_css(".tab.tomorrow.active")
+      expect(page).not_to have_css(".tab.day_after_tomorrow.active")
     end
   end
 
@@ -61,8 +61,8 @@ RSpec.feature "Air quality alerts", feature: true do
       within(".alert-guidance") do
         expect_to_see_guidance_for(:very_high)
       end
-      expect(page).to have_css(".tab.day_after_tomorrow.daqi-alert-after-today-selected-level-10")
-      expect(page).not_to have_css(".tab.tomorrow.daqi-alert-after-today-selected-level-4")
+      expect(page).to have_css(".tab.day_after_tomorrow.active")
+      expect(page).not_to have_css(".tab.tomorrow.active")
     end
   end
 end

--- a/spec/support/features/forecast_helper.rb
+++ b/spec/support/features/forecast_helper.rb
@@ -13,9 +13,9 @@ module Features
     def switch_to_tab_for(day)
       case day
       when :tomorrow
-        find(".tab.tomorrow a").trigger("click")
+        find(".tab.tomorrow").trigger("click")
       when :day_after_tomorrow
-        find(".tab.day_after_tomorrow a").trigger("click")
+        find(".tab.day_after_tomorrow").trigger("click")
       else
         raise "day: #{day} not expected"
       end


### PR DESCRIPTION
## Context
Currently switching zone or day involves a lot of JS and passing of variables. The forecast (the tabs), the map, and the predictions (UV, pollen, temperature) are all handled separately which makes the logic complex.

## Changes in this PR
This PR changes the page content to be driven by the URL parameters `zone` and `day`. The existing Turbo frames/stream are replaced by a single Turbo frame for the whole forecast + map + predictions block, which is updated by a form containing the zone and day information.

This has the added benefit that shared URLs can be more specific.