### PR TITLE
Handle invalid parameter values

### DIFF
--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -2,7 +2,7 @@ class ForecastsController < ApplicationController
   def show
     @maptiler_api_key = ENV.fetch("MAPTILER_API_KEY")
     @zone = zone
-    @date = Date.parse(params.fetch("date")) if params[:date]
+    @date = date
     @day = @date ? day_from_date(@date) : params.fetch("day", "today")
     @pollutant = params.fetch("pollutant", "Total")
     @map_lat = params.fetch("lat", nil)
@@ -22,8 +22,6 @@ class ForecastsController < ApplicationController
       "tomorrow"
     elsif date >= Date.tomorrow
       "day_after_tomorrow"
-    else
-      "today"
     end
   end
 
@@ -44,5 +42,11 @@ class ForecastsController < ApplicationController
     return Zone.default unless params[:zone]
 
     Zone.find_by(name: params[:zone])
+  end
+
+  def date
+    Date.parse(params.fetch("date")) if params[:date].present?
+  rescue ArgumentError
+    Date.today # default to today
   end
 end

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -4,7 +4,7 @@ class ForecastsController < ApplicationController
     @zone = zone
     @date = date
     @day = @date ? day_from_date(@date) : day
-    @pollutant = params.fetch("pollutant", "Total")
+    @pollutant = pollutant
     @map_lat = params.fetch("lat", nil)
     @map_lon = params.fetch("lon", nil)
     @map_zoom = params.fetch("zoom", nil)
@@ -52,5 +52,11 @@ class ForecastsController < ApplicationController
     return params.fetch("day") if %w[today tomorrow day_after_tomorrow].include?(params.dig("day"))
 
     "today" # default to today
+  end
+
+  def pollutant
+    return params.fetch("pollutant", "Total") if %w[Total PM10 PM25 NO2 O3].include?(params.dig("pollutant"))
+
+    "Total" # default to Total
   end
 end

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -3,7 +3,7 @@ class ForecastsController < ApplicationController
     @maptiler_api_key = ENV.fetch("MAPTILER_API_KEY")
     @zone = zone
     @date = date
-    @day = @date ? day_from_date(@date) : params.fetch("day", "today")
+    @day = @date ? day_from_date(@date) : day
     @pollutant = params.fetch("pollutant", "Total")
     @map_lat = params.fetch("lat", nil)
     @map_lon = params.fetch("lon", nil)
@@ -33,8 +33,6 @@ class ForecastsController < ApplicationController
       forecasts.second
     when "day_after_tomorrow"
       forecasts.third
-    else
-      raise ArgumentError, "Invalid day: #{day}"
     end
   end
 
@@ -48,5 +46,11 @@ class ForecastsController < ApplicationController
     Date.parse(params.fetch("date")) if params[:date].present?
   rescue ArgumentError
     Date.today # default to today
+  end
+
+  def day
+    return params.fetch("day") if %w[today tomorrow day_after_tomorrow].include?(params.dig("day"))
+
+    "today" # default to today
   end
 end

--- a/spec/controllers/forecasts_controller_spec.rb
+++ b/spec/controllers/forecasts_controller_spec.rb
@@ -111,4 +111,26 @@ RSpec.describe ForecastsController do
       end
     end
   end
+
+  context "when a _pollutant_ parameter is received" do
+    before do
+      get :show, params: {pollutant: pollutant}
+    end
+
+    context "when the pollutant is recognised" do
+      let(:pollutant) { "PM10" }
+
+      it "set the pollutant to the given value" do
+        expect(assigns(:pollutant)).to eq("PM10")
+      end
+    end
+
+    context "when the pollutant is not recognised" do
+      let(:pollutant) { "invalid" }
+
+      it "defaults to showing the Total forecast" do
+        expect(assigns(:pollutant)).to eq("Total")
+      end
+    end
+  end
 end

--- a/spec/controllers/forecasts_controller_spec.rb
+++ b/spec/controllers/forecasts_controller_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe ForecastsController do
           expect(assigns(:day_forecast)).to eq(forecasts.data.third)
         end
       end
+
+      context "when the date is invalid" do
+        let(:date) { "invalid" }
+
+        it "shows the forecast for today" do
+          expect(assigns(:day_forecast)).to eq(forecasts.data.first)
+        end
+      end
     end
   end
 end

--- a/spec/controllers/forecasts_controller_spec.rb
+++ b/spec/controllers/forecasts_controller_spec.rb
@@ -35,20 +35,25 @@ RSpec.describe ForecastsController do
       expect(response).to render_template("show")
     end
 
-    context "when a recognised _day_ parameter is received" do
-      it "renders the _show_ template" do
-        get :show, params: {day: :today}
-
-        expect(CercForecastService).to have_received(:latest_forecasts_for).with(southwark)
-        expect(response).to render_template("show")
+    context "when a _day_ parameter is received" do
+      before do
+        get :show, params: {day: day}
       end
-    end
 
-    context "when an unrecognised _day_ parameter is received" do
-      it "raises a helpful error" do
-        expect {
-          get :show, params: {day: :yesterday}
-        }.to raise_error(ArgumentError, "Invalid day: yesterday")
+      context "when a recognised _day_ parameter is received" do
+        let(:day) { "tomorrow" }
+
+        it "shows the forecast for the given day" do
+          expect(assigns(:day_forecast)).to eq(forecasts.data.second)
+        end
+      end
+
+      context "when an unrecognised _day_ parameter is received" do
+        let(:day) { "invalid" }
+
+        it "shows today's forecast" do
+          expect(assigns(:day_forecast)).to eq(forecasts.data.first)
+        end
       end
     end
 

--- a/spec/controllers/forecasts_controller_spec.rb
+++ b/spec/controllers/forecasts_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ForecastsController do
   before do
     allow(Zone).to receive(:find_by).and_return(barnet)
     allow(Zone).to receive(:default).and_return(southwark)
+    allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
   end
 
   let(:forecasts) do
@@ -14,8 +15,6 @@ RSpec.describe ForecastsController do
   describe "GET :show" do
     context "when NO zone is given" do
       it "obtains forecasts for the default zone (Southwark) from the CercForecastService" do
-        allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
-
         get :show
 
         expect(CercForecastService).to have_received(:latest_forecasts_for).with(southwark)
@@ -24,8 +23,6 @@ RSpec.describe ForecastsController do
 
     context "when zone IS given" do
       it "obtains forecasts for the given zone from the CercForecastService" do
-        allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
-
         get :show, params: {zone: double}
 
         expect(CercForecastService).to have_received(:latest_forecasts_for).with(barnet)
@@ -33,8 +30,6 @@ RSpec.describe ForecastsController do
     end
 
     it "renders the _show_ template" do
-      allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
-
       get :show
 
       expect(response).to render_template("show")
@@ -42,8 +37,6 @@ RSpec.describe ForecastsController do
 
     context "when a recognised _day_ parameter is received" do
       it "renders the _show_ template" do
-        allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
-
         get :show, params: {day: :today}
 
         expect(CercForecastService).to have_received(:latest_forecasts_for).with(southwark)
@@ -53,8 +46,6 @@ RSpec.describe ForecastsController do
 
     context "when an unrecognised _day_ parameter is received" do
       it "raises a helpful error" do
-        allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
-
         expect {
           get :show, params: {day: :yesterday}
         }.to raise_error(ArgumentError, "Invalid day: yesterday")
@@ -63,7 +54,6 @@ RSpec.describe ForecastsController do
 
     context "when a _date_ parameter is received" do
       before do
-        allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
         get :show, params: {date: date.to_s}
       end
 


### PR DESCRIPTION
## Context
Previously invalid parameter values for date, day, and pollutant would cause errors.

## Changes in this PR
This PR adds error handling with fallbacks for date, day, and pollution. Date and day fallback to today, pollution falls back to 'Total' (ie all pollution).
