### PR TITLE
Drive zone forecast with map search

### DIFF
--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -11,6 +11,16 @@ class ForecastsController < ApplicationController
 
     @forecasts = CercForecastService.latest_forecasts_for(@zone).data
     @day_forecast = forecast_for_day(@day, @forecasts)
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.replace("forecasts-frame-top", partial: "forecasts/top"),
+          turbo_stream.replace("forecasts-frame-bottom", partial: "forecasts/bottom")
+        ]
+      end
+      format.html
+    end
   end
 
   private

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -31,6 +31,7 @@ export default class MapController extends Controller {
   mapTargetConnected() {
     this.updateSettings();
     this.createMap();
+    this.updateForecastZone(this.settings.center);
   }
 
   updateSettings() {
@@ -137,6 +138,7 @@ export default class MapController extends Controller {
         apiKey: this.settings.maptilerApiKey,
         position: "topleft",
         country: ["GB"],
+        placeholder: "Enter a place, address, or postcode",
         proximity: [-0.116773, 51.510357], // Big Ben, lng lat
         types: [
           "region",
@@ -154,6 +156,9 @@ export default class MapController extends Controller {
           "road",
           "poi",
         ],
+      })
+      .on("pick", (e) => {
+        this.updateForecastZone(e.feature?.geometry?.coordinates);
       })
       .addTo(this.map);
   }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -4,11 +4,13 @@ import "@maptiler/geocoding-control/leaflet"; // Geocoding (search) control
 import { LocateControl } from "leaflet.locatecontrol"; // Geolocation control
 import "leaflet.fullscreen"; // Fullscreen control
 import * as zones from "../zone_boundaries/zone-boundaries";
+import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
 
 export default class MapController extends Controller {
   static targets = [
     "map",
     "pollutantSelector",
+    "zoneSelector",
     "daySelector",
     "latField",
     "lngField",
@@ -80,7 +82,27 @@ export default class MapController extends Controller {
 
     this.map.on("zoomend moveend", () => {
       this.updateUrl();
+      this.updateForecastZone([
+        this.map.getCenter().lat,
+        this.map.getCenter().lng,
+      ]);
     });
+  }
+
+  updateForecastZone(coordinatesLatLng) {
+    const coordinatesLngLat = [coordinatesLatLng[1], coordinatesLatLng[0]];
+    const zones = this.findZones(coordinatesLngLat);
+    let zone;
+    if (!zones || zones.length === 0) {
+      return;
+    } else if (zones.length > 1) {
+      zone = zones[this.map.getZoom() <= 12 ? 1 : 0]; // Show more specific zone at higher zoom
+    } else {
+      zone = zones[0];
+    }
+
+    this.zoneSelectorTarget.value = zone.properties.name;
+    this.zoneSelectorTarget.form.requestSubmit();
   }
 
   updateUrl() {
@@ -249,6 +271,25 @@ export default class MapController extends Controller {
         }
       });
     });
+  }
+
+  findZones(coordinatesLngLat) {
+    if (!coordinatesLngLat) {
+      return;
+    }
+
+    const matches = [];
+    for (const [, zone] of Object.entries(zones)) {
+      // Coordinated have to be in the format [longitude, latitude]
+      if (booleanPointInPolygon(coordinatesLngLat, zone)) {
+        matches.push(zone);
+      }
+    }
+
+    // Sort by zone level so more specific zones are returned first
+    matches.sort((a, b) => b.properties.level - a.properties.level);
+
+    return matches;
   }
 
   updateMap() {

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,7 +1,7 @@
 class Zone < ApplicationRecord
-  DEFAULT_ZONE_SOUTHWARK_CERC_ID = 29
+  DEFAULT_ZONE_CENTRAL_LONDON_CERC_ID = 55
 
   def self.default
-    find_by!(cerc_id: DEFAULT_ZONE_SOUTHWARK_CERC_ID)
+    find_by!(cerc_id: DEFAULT_ZONE_CENTRAL_LONDON_CERC_ID)
   end
 end

--- a/app/views/forecasts/_bottom.html.erb
+++ b/app/views/forecasts/_bottom.html.erb
@@ -1,0 +1,6 @@
+<turbo-frame id="forecasts-frame-bottom">
+  <%= render "alert_guidance" %>
+  <%= render "predictions" %>
+  <%= render "sharing" %>
+  <span class="forecast-timestamp">Forecast updated at <%= @day_forecast.air_pollution.forecasted_at.strftime("%H:%M on %A %d %B %Y") %></span>
+</turbo-frame>

--- a/app/views/forecasts/_location_selector.html.erb
+++ b/app/views/forecasts/_location_selector.html.erb
@@ -1,8 +1,5 @@
 <%= form_tag(false, method: :get, id: "forecast-form", data: { "turbo-stream": "replace", "action": "submit->map#updateMap"}) do %>
-  <%= select_tag :zone, 
-  options_for_select(Zone.all.order(:name).map(&:name), @zone.name),
-  data: { "forecast-target": "zoneSelector", action: "change->forecast#changeZone" }
-  %>
+  <%= hidden_field_tag :zone, @zone.name, data: { "forecast-target": "zoneSelector", "map-target": "zoneSelector", action: "change->forecast#changeZone" } %>
   <%= hidden_field_tag :date, @date, data: { "forecast-target": "daySelector", "map-target": "daySelector" } %>
   <%= hidden_field_tag :lat, @map_lat, data: { "map-target": "latField" } %>
   <%= hidden_field_tag :lng, @map_lng, data: { "map-target": "lngField" } %>

--- a/app/views/forecasts/_location_selector.html.erb
+++ b/app/views/forecasts/_location_selector.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(false, method: :get, id: "forecast-form") do %>
+<%= form_tag(false, method: :get, id: "forecast-form", data: { "turbo-stream": "replace", "action": "submit->map#updateMap"}) do %>
   <%= select_tag :zone, 
   options_for_select(Zone.all.order(:name).map(&:name), @zone.name),
   data: { "forecast-target": "zoneSelector", action: "change->forecast#changeZone" }

--- a/app/views/forecasts/_top.html.erb
+++ b/app/views/forecasts/_top.html.erb
@@ -1,0 +1,4 @@
+<turbo-frame id="forecasts-frame-top">
+  <%= render "location_selector" %>
+  <%= render "forecast_tabs" %>
+</turbo-frame>

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -5,16 +5,15 @@
 <h2 class="text-xl font-bold mb-2">Air quality forecast</h2>
 <p>The air quality forecast displays levels of air pollution, ultraviolet rays, pollen, and temperature over the next three days for your area of interest.</p>
 
-<turbo-frame id="forecasts-frame" data-controller="map forecast">
-    <%= render "location_selector" %>
-    <%= render "forecast_tabs" %>
+<div data-controller="map forecast">
+  <%= render "top" %>
+
   <div class="tab-contents">
-    <%= render "alert_guidance" %>
     <%= render "map" %>
-    <%= render "predictions" %>
-    <%= render "sharing" %>
-    <span class="forecast-timestamp">Forecast updated at <%= @day_forecast.air_pollution.forecasted_at.strftime("%H:%M on %A %d %B %Y") %></span>
+
+    <%= render "bottom" %>
   </div>
-</turbo-frame>
+</div>
+
 <%= render "subscribe" %>
 <%= render "learning" %>

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+   <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <h2 class="text-xl font-bold mb-2">Air quality forecast</h2>
 <p>The air quality forecast displays levels of air pollution, ultraviolet rays, pollen, and temperature over the next three days for your area of interest.</p>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= favicon_link_tag asset_path('favicon-32x32.png'), :rel => 'icon', :type =>  'image/png' %>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", media: 'all', "data-turbolinks-track" => "reload" %>
+    <%= yield(:head) %>
   </head>
   <body class="">
     <div class="container mx-auto max-w-6xl">

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.10",
     "@maptiler/geocoding-control": "^2.0.0",
+    "@turf/boolean-point-in-polygon": "^7.1.0",
     "depcheck": "^1.4.7",
     "leaflet.fullscreen": "^3.0.2",
     "leaflet.locatecontrol": "^0.82.0",

--- a/spec/controllers/forecasts_controller_spec.rb
+++ b/spec/controllers/forecasts_controller_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe ForecastsController do
-  let(:southwark) { double("Southwark") }
+  let(:central_london) { double("Central London") }
   let(:barnet) { double("Barnet") }
 
   before do
     allow(Zone).to receive(:find_by).and_return(barnet)
-    allow(Zone).to receive(:default).and_return(southwark)
+    allow(Zone).to receive(:default).and_return(central_london)
     allow(CercForecastService).to receive(:latest_forecasts_for).and_return(forecasts)
   end
 
@@ -14,10 +14,10 @@ RSpec.describe ForecastsController do
 
   describe "GET :show" do
     context "when NO zone is given" do
-      it "obtains forecasts for the default zone (Southwark) from the CercForecastService" do
+      it "obtains forecasts for the default zone (Central London) from the CercForecastService" do
         get :show
 
-        expect(CercForecastService).to have_received(:latest_forecasts_for).with(southwark)
+        expect(CercForecastService).to have_received(:latest_forecasts_for).with(central_london)
       end
     end
 

--- a/spec/factories/forecast_zones.rb
+++ b/spec/factories/forecast_zones.rb
@@ -5,8 +5,8 @@
 
 FactoryBot.define do
   factory :forecast_zone do
-    id { 29 }
-    name { "Southwark" }
+    id { 55 }
+    name { "Central London" }
     type { 1 }
 
     initialize_with { new(**attributes) }

--- a/spec/feature_steps/zone_steps.rb
+++ b/spec/feature_steps/zone_steps.rb
@@ -1,3 +1,3 @@
 def create_default_zone
-  FactoryBot.create(:zone, name: "Southwark", cerc_id: 29)
+  FactoryBot.create(:zone, name: "Central London", cerc_id: 55)
 end

--- a/spec/fixtures/api/forecasts.rb
+++ b/spec/fixtures/api/forecasts.rb
@@ -11,11 +11,11 @@ module Fixtures
         }
       end
 
-      def zone_object(zone_id: 29, forecasts: [])
+      def zone_object(zone_id: 55, forecasts: [])
         {
           "forecasts" => forecasts.presence || [zone_forecast],
           "zone_id" => zone_id,
-          "zone_name" => "Southwark",
+          "zone_name" => "Central London",
           "zone_type" => 1
         }
       end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Zone do
   describe "::default" do
-    before { FactoryBot.create(:zone, cerc_id: Zone::DEFAULT_ZONE_SOUTHWARK_CERC_ID) }
+    before { FactoryBot.create(:zone, cerc_id: Zone::DEFAULT_ZONE_CENTRAL_LONDON_CERC_ID) }
 
-    it "returns Southwark's Zone record" do
-      expect(Zone.default.cerc_id).to eq(Zone::DEFAULT_ZONE_SOUTHWARK_CERC_ID)
+    it "returns Central London zone record" do
+      expect(Zone.default.cerc_id).to eq(Zone::DEFAULT_ZONE_CENTRAL_LONDON_CERC_ID)
     end
   end
 end

--- a/spec/services/cerc_forecast_service_spec.rb
+++ b/spec/services/cerc_forecast_service_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe CercForecastService do
   describe "::latest_forecasts_for(zone)" do
-    let(:zone) { FactoryBot.create(:zone, cerc_id: 29) }
+    let(:zone) { FactoryBot.create(:zone, cerc_id: 55) }
 
     context "when the cache is stale" do
       let(:latest_forecasts_from_api) { Fixtures::API.all_forecasts }

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,17 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
+"@turf/boolean-point-in-polygon@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.1.0.tgz#dec07b467d74b4409eb03acc60b874958f71b49a"
+  integrity sha512-mprVsyIQ+ijWTZwbnO4Jhxu94ZW2M2CheqLiRTsGJy0Ooay9v6Av5/Nl3/Gst7ZVXxPqMeMaFYkSzcTc87AKew==
+  dependencies:
+    "@turf/helpers" "^7.1.0"
+    "@turf/invariant" "^7.1.0"
+    "@types/geojson" "^7946.0.10"
+    point-in-polygon-hao "^1.1.0"
+    tslib "^2.6.2"
+
 "@turf/clone@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-7.1.0.tgz#b0cbf60b84fadd30ae8411f12d3bdcd3e773577f"
@@ -556,6 +567,15 @@
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.1.0.tgz#eb734e291c9c205822acdd289fe20e91c3cb1641"
   integrity sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==
   dependencies:
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.6.2"
+
+"@turf/invariant@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-7.1.0.tgz#c90cffa093291316b597212396d68bf9e465cf2e"
+  integrity sha512-OCLNqkItBYIP1nE9lJGuIUatWGtQ4rhBKAyTfFu0z8npVzGEYzvguEeof8/6LkKmTTEHW53tCjoEhSSzdRh08Q==
+  dependencies:
+    "@turf/helpers" "^7.1.0"
     "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
@@ -2150,6 +2170,11 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
+
+point-in-polygon-hao@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/point-in-polygon-hao/-/point-in-polygon-hao-1.1.0.tgz#37f5f4fbe14e89fa8a3bb7f67c9158079d2ede7c"
+  integrity sha512-3hTIM2j/v9Lio+wOyur3kckD4NxruZhpowUbEgmyikW+a2Kppjtu1eN+AhnMQtoHW46zld88JiYWv6fxpsDrTQ==
 
 polygon-clipping@^0.15.3:
   version "0.15.7"


### PR DESCRIPTION
## Context
Currently the user specifies the location they want a forecast for by using a dropdown select. Separately there is a search control on the map to find places of interest. These two are not connected.
Trello: https://trello.com/c/00JLpGKY/110-location-search, https://trello.com/c/wk90EFVM/79-investigate-how-map-zooming-panning-might-impact-page-content

There is also an issue with ghost maps being retained when switching between views with Turbo, and in some cases the use of the forward and back buttons on the browser not working. Trello: https://trello.com/c/rhN3V2Fa/128-fix-ghost-maps-on-turbo-back-and-forth

## Changes in this PR
This PR removes the zone select and makes the map search and pan change the forecast zone.

To achieve this we first have to change the way we render updates on the page. Currently we have a single Turbo frame that contains all of the forecast content. This allows us to update everything in one go when the location selector form changes. However, it also means replacing the map unnecessarily, and that is a unuseable when the map is driving those changes in the first place.

This PR splits the frame into two, a top and a bottom (with the map inbetween them). We use a Turbo stream, triggered by the location selector form to update these frames.

We then add two listeners, one for search and one for pan/zoom. When the map is panned or zoomed, get the new centre coordinates and look them up in the zone polygons. When the map is searched we get the coordinates of the selected search result. This may return more than one zone where there are overlapping zones of different levels. We choose between them using the zoom. If the coordinate falls outside of a zone, we ignore it and stay on the zone we were one before.

## Screenshots of UI changes

### Before
<img width="387" alt="image" src="https://github.com/user-attachments/assets/db8aae0d-6676-4f9c-bd93-c3b43b9e8cdb">


### After
<img width="391" alt="image" src="https://github.com/user-attachments/assets/8ed64c2a-436e-419c-b44d-e7d056fc21fc">