### PR TITLE
Add pollution indicators to map zone labels

### DIFF
--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -28,7 +28,6 @@
     display: flex;
     align-items: center;
 
-    /* 
     &::before {
       content: "";
       display: inline-block;
@@ -36,9 +35,47 @@
       height: 10px;
       border-radius: 50%;
       margin-right: 4px;
-      background-color: red;
     }
-    */
+
+    &.daqi-level-1::before {
+      background-color: var(--daqi-level-1-bg);
+    }
+
+    &.daqi-level-2::before {
+      background-color: var(--daqi-level-2-bg);
+    }
+
+    &.daqi-level-3::before {
+      background-color: var(--daqi-level-3-bg);
+    }
+
+    &.daqi-level-4::before {
+      background-color: var(--daqi-level-4-bg);
+    }
+
+    &.daqi-level-5::before {
+      background-color: var(--daqi-level-5-bg);
+    }
+
+    &.daqi-level-6::before {
+      background-color: var(--daqi-level-6-bg);
+    }
+
+    &.daqi-level-7::before {
+      background-color: var(--daqi-level-7-bg);
+    }
+
+    &.daqi-level-8::before {
+      background-color: var(--daqi-level-8-bg);
+    }
+
+    &.daqi-level-9::before {
+      background-color: var(--daqi-level-9-bg);
+    }
+
+    &.daqi-level-10::before {
+      background-color: var(--daqi-level-10-bg);
+    }
   }
 }
 


### PR DESCRIPTION
## Changes in this PR
This PR adds coloured circles to the map zone labels to show the current average pollution for the zone.

Trello: https://trello.com/c/uLIXdskr/131-show-aq-index-on-the-map-in-place-of-the-labels-see-figma

## Screenshots of UI changes

### Before
<img width="350" alt="image" src="https://github.com/user-attachments/assets/7b303a14-8095-4962-bc36-5c013dcf18bd">

### After
<img width="344" alt="image" src="https://github.com/user-attachments/assets/50d970d3-9dfd-4263-917c-41f3c1dd1a2c">