### PR TITLE
Remove Solargraph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ group :development do
   gem "spring-commands-rspec"
   gem "web-console", ">= 3.3.0"
   gem "htmlbeautifier"
-  gem "solargraph"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,6 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
-    backport (1.2.0)
     base64 (0.2.0)
     benchmark (0.4.0)
     better_errors (2.10.1)
@@ -132,7 +131,6 @@ GEM
     docile (1.4.0)
     dotenv (3.1.4)
     drb (2.2.1)
-    e2mmap (0.1.0)
     erubi (1.13.0)
     execjs (2.9.1)
     factory_bot (6.4.6)
@@ -163,17 +161,12 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jaro_winkler (1.6.0)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.8.2)
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     launchy (3.0.1)
       addressable (~> 2.8)
@@ -286,7 +279,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -294,8 +286,6 @@ GEM
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.3.9)
     rollbar (3.6.0)
     rouge (1.11.1)
@@ -361,22 +351,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    solargraph (0.50.0)
-      backport (~> 1.2)
-      benchmark
-      bundler (~> 2.0)
-      diff-lcs (~> 1.4)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      parser (~> 3.0)
-      rbs (~> 2.0)
-      reverse_markdown (~> 2.0)
-      rubocop (~> 1.38)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
     spring (4.2.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -435,7 +409,6 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.37)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -484,7 +457,6 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers (~> 6.0)
   simplecov
-  solargraph
   spring
   spring-commands-rspec
   standard


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Context
Solargraph, a Ruby language server, has a problem with .erb files and throws a lot of false positives (see https://github.com/Shopify/ruby-lsp/issues/2282)

<img width="844" alt="image" src="https://github.com/user-attachments/assets/ba172058-8f71-4dc0-9d79-20cf83747001">

This is extremely irritating.

## Changes in this PR
This PR removes Solargraph, which is not required for the app.

An alternative for developers to get similar functionality is to use the Ruby-LSP extension on VS Code.
