### PR TITLE
Add air quality alerts page and banner

### DIFF
--- a/app/assets/stylesheets/air-quality-alert-banner.scss
+++ b/app/assets/stylesheets/air-quality-alert-banner.scss
@@ -1,0 +1,21 @@
+.air-quality-alert-banner {
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+
+  &.no-alert {
+    background-color: var(--main-colour-lightest);
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+    margin-right: 0.25rem;
+    margin-bottom: 2px;
+    display: inline-block;
+  }
+
+  a {
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/air-quality-alerts-page.scss
+++ b/app/assets/stylesheets/air-quality-alerts-page.scss
@@ -1,0 +1,82 @@
+.air-quality-alerts-table {
+  margin-top: 1rem;
+  border-collapse: collapse;
+  width: 100%;
+
+  th,
+  td {
+    padding: 0.5rem;
+  }
+
+  .zone-name {
+    font-weight: bold;
+    background-color: var(--main-colour-lightest);
+  }
+
+  .levels {
+    td {
+      border-right: 1px solid #ccc;
+
+      .label {
+        font-weight: bold;
+        margin-bottom: -5px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        &::after {
+          content: "";
+          float: right;
+          width: 15px;
+          height: 15px;
+          border-radius: 50%;
+          border: 1px solid var(--main-colour-light);
+        }
+
+        &.daqi-level-1::after {
+          background-color: var(--daqi-level-1-bg);
+        }
+
+        &.daqi-level-2::after {
+          background-color: var(--daqi-level-2-bg);
+        }
+
+        &.daqi-level-3::after {
+          background-color: var(--daqi-level-3-bg);
+        }
+
+        &.daqi-level-4::after {
+          background-color: var(--daqi-level-4-bg);
+        }
+
+        &.daqi-level-5::after {
+          background-color: var(--daqi-level-5-bg);
+        }
+
+        &.daqi-level-6::after {
+          background-color: var(--daqi-level-6-bg);
+        }
+
+        &.daqi-level-7::after {
+          background-color: var(--daqi-level-7-bg);
+        }
+
+        &.daqi-level-8::after {
+          background-color: var(--daqi-level-8-bg);
+        }
+
+        &.daqi-level-9::after {
+          background-color: var(--daqi-level-9-bg);
+        }
+
+        &.daqi-level-10::after {
+          background-color: var(--daqi-level-10-bg);
+        }
+      }
+
+      .value {
+        font-size: 0.75rem;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.tailwind.css.scss
+++ b/app/assets/stylesheets/application.tailwind.css.scss
@@ -3,6 +3,7 @@
 @import "leaflet.locatecontrol/dist/L.Control.Locate.min.css"; /* Geolocation button */
 @import "leaflet.fullscreen/Control.FullScreen.css"; /* Fullscreen button */
 @import "header.scss";
+@import "air-quality-alert-banner.scss";
 @import "forecast-page.scss";
 @import "health-advice-page.scss";
 @import "air-quality-alerts-page.scss";
@@ -20,4 +21,26 @@
   --main-colour: #3880d1;
   --main-colour-light: #dae7f7;
   --main-colour-lightest: #edf4fb;
+}
+
+.air-quality-alert-banner {
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+
+  &.no-alert {
+    background-color: var(--main-colour-lightest);
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+    margin-right: 0.25rem;
+    margin-bottom: 2px;
+    display: inline-block;
+  }
+
+  a {
+    text-decoration: underline;
+  }
 }

--- a/app/assets/stylesheets/application.tailwind.css.scss
+++ b/app/assets/stylesheets/application.tailwind.css.scss
@@ -5,6 +5,7 @@
 @import "header.scss";
 @import "forecast-page.scss";
 @import "health-advice-page.scss";
+@import "air-quality-alerts-page.scss";
 @import "map.scss";
 @import "daqi-levels.scss";
 @import "share.scss";

--- a/app/assets/stylesheets/daqi-levels.scss
+++ b/app/assets/stylesheets/daqi-levels.scss
@@ -23,7 +23,8 @@
 
 .daqi-scale,
 .tabs,
-.daqi-table {
+.daqi-table,
+.air-quality-alert-banner {
   .daqi-level-1 {
     background-color: var(--daqi-level-1-bg);
     color: var(--daqi-level-1-text);
@@ -75,22 +76,22 @@
   }
 }
 
-.daqi-low-level {
+.daqi-level-low {
   color: var(--daqi-level-2-text);
   background-color: var(--daqi-level-2-bg);
 }
 
-.daqi-moderate-level {
+.daqi-level-moderate {
   color: var(--daqi-level-5-text);
   background-color: var(--daqi-level-5-bg);
 }
 
-.daqi-high-level {
+.daqi-level-high {
   color: var(--daqi-level-8-text);
   background-color: var(--daqi-level-8-bg);
 }
 
-.daqi-very-high-level {
+.daqi-level-very-high {
   color: var(--daqi-level-10-text);
   background-color: var(--daqi-level-10-bg);
 }

--- a/app/components/air_quality_alert_banner_component.html.erb
+++ b/app/components/air_quality_alert_banner_component.html.erb
@@ -1,0 +1,7 @@
+<div class="air-quality-alert-banner <%= alert? ? "daqi-level-#{@level_label&.parameterize}" : "no-alert" %> <%= icon_stroke_colour_class %>">
+  <div>
+    <%= helpers.render_svg "exclamation_triangle" if alert? %>
+    <strong><%= message %></strong>
+  </div>
+  <%= link_to "Learn more", alerts_path if alert? %>
+</div>

--- a/app/components/air_quality_alert_banner_component.rb
+++ b/app/components/air_quality_alert_banner_component.rb
@@ -1,0 +1,42 @@
+class AirQualityAlertBannerComponent < ViewComponent::Base
+  def initialize
+    @level_label = highest_alert
+  end
+
+  def alert?
+    @level_label != "LOW"
+  end
+
+  def message
+    if alert?
+      "#{highest_alert.humanize} air pollution alert"
+    else
+      "No air pollution alerts"
+    end
+  end
+
+  def icon_stroke_colour_class
+    ["HIGH", "VERY HIGH"].include?(@level_label) ? "stroke-white" : "stroke-black"
+  end
+
+  private
+
+  def highest_alert
+    [
+      "VERY HIGH",
+      "HIGH",
+      "MODERATE",
+      "LOW"
+    ].each do |label|
+      return label if pollution_labels.flatten.include?(label)
+    end
+  end
+
+  def pollution_labels
+    CercForecastService.latest_forecasts.map do |cached_forecast|
+      cached_forecast.data.map do |forecast|
+        forecast.air_pollution[:label]
+      end
+    end
+  end
+end

--- a/app/views/forecasts/alerts.html.erb
+++ b/app/views/forecasts/alerts.html.erb
@@ -1,0 +1,47 @@
+<div class="text-block p-4 mx-0">
+  <h1>Air pollution alerts for Greater London and the South East</h1>
+  <p>The list below show all of the air pollution alerts fot the next three days.</p>
+  <p>If an area is not shown below, the air pollution is expected to be low for that region for all three days.</p>
+  <p>See the <%= link_to "health advice", health_advice_path %> page to learn more about how the expected pollution levels might affect your health.</p>
+
+  <table class="air-quality-alerts-table">
+    <colgroup>
+      <col class="w-1/3">
+      <col class="w-1/3">
+      <col class="w-1/3">
+    </colgroup>
+    <thead>
+      <tr>
+        <th>Today
+        <th><%= (Date.today + 1.day).strftime("%A") %></th>
+        <th><%= (Date.today + 2.days).strftime("%A") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% no_alerts = true %>
+      <% CercForecastService.latest_forecasts.each do |cached_forecast| %>
+        <% next unless cached_forecast.data.map { |f| f.air_quality_alert? }.count(true).positive? %>
+        <% no_alerts = false %>
+        <tr class="zone-name">
+          <td colspan="3"><%= cached_forecast.data.first.zone[:name] %></td>
+        </tr>
+        <tr class="levels">
+          <% cached_forecast.data.each do |forecast| %>
+            <td>
+              <span class="label <%= "daqi-level-#{forecast.air_pollution[:total]}"%>"><%= forecast.air_pollution[:label].humanize %></span>
+              <span class="value">Index <%= forecast.air_pollution[:total] %>/10</span>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+
+      <% if no_alerts %>
+        <tr class="text-center">
+          <td>No alerts</td>
+          <td>No alerts</td>
+          <td>No alerts</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
   <body class="">
     <div class="container mx-auto max-w-6xl">
       <%= render "shared/header" %>
+      <%= render "shared/alert_banner" %>
       <main role="main">
         <%= render "layouts/messages" %>
         <%= yield %>

--- a/app/views/shared/_alert_banner.html.erb
+++ b/app/views/shared/_alert_banner.html.erb
@@ -1,0 +1,1 @@
+<%= render(AirQualityAlertBannerComponent.new) %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,6 +2,7 @@
   <nav>
     <ul>
       <li><%= active_link_to "Air quality forecast", forecast_path %></li>
+      <li><%= active_link_to "Air pollution alerts", alerts_path %></li>
       <li><%= active_link_to "Alert service", subscribe_path %></li>
       <li><%= active_link_to "Health advice", health_advice_path %></li>
       <li><%= active_link_to "About", about_path %></li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,6 +8,7 @@
   <nav>
     <ul class="hidden" data-navigation-target="menuList">
       <li><%= active_link_to "Air quality forecast", forecast_path %></li>
+      <li><%= active_link_to "Air pollution alerts", alerts_path %></li>
       <li><%= active_link_to "Alert service", subscribe_path %></li>
       <li><%= active_link_to "Health advice", health_advice_path %></li>
       <li><%= active_link_to "About", about_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   get :forecast, to: "forecasts#show"
   get :pollutant_forecasts, to: "forecasts#pollutant_forecasts"
+  get :alerts, to: "forecasts#alerts"
   get :subscribe, to: "subscriptions#new"
   get :health_advice, to: "pages#health_advice"
   get :about, to: "pages#about"

--- a/spec/components/air_quality_alert_banner_component_spec.rb
+++ b/spec/components/air_quality_alert_banner_component_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+RSpec.describe AirQualityAlertBannerComponent, type: :component do
+  let(:forecasts) { [FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, air_pollution_level))] }
+  let(:cached_forecast) { FactoryBot.build(:cached_forecast, data: forecasts) }
+
+  before do
+    allow(CercForecastService).to receive(:latest_forecasts).and_return([cached_forecast])
+  end
+
+  let(:component) { AirQualityAlertBannerComponent.new }
+
+  describe "alert?" do
+    context "when the air pollution level is LOW" do
+      let(:air_pollution_level) { :low }
+
+      it "returns false" do
+        expect(component.alert?).to eq(false)
+      end
+    end
+
+    context "when the air pollution level is not LOW" do
+      let(:air_pollution_level) { :high }
+
+      it "returns true" do
+        expect(component.alert?).to eq(true)
+      end
+    end
+  end
+
+  describe "message" do
+    context "when there is an alert" do
+      let(:air_pollution_level) { :high }
+
+      it "returns a message with the highest alert" do
+        expect(component.message).to eq("High air pollution alert")
+      end
+    end
+
+    context "when there is no alert" do
+      let(:air_pollution_level) { :low }
+
+      it "returns a message with no alerts" do
+        expect(component.message).to eq("No air pollution alerts")
+      end
+    end
+  end
+
+  describe "icon_stroke_colour_class" do
+    context "when the highest alert is HIGH" do
+      let(:air_pollution_level) { :high }
+
+      it "returns _stroke-white_" do
+        expect(component.icon_stroke_colour_class).to eq("stroke-white")
+      end
+    end
+
+    context "when the highest alert is not HIGH" do
+      let(:air_pollution_level) { :low }
+
+      it "returns _stroke-black_" do
+        expect(component.icon_stroke_colour_class).to eq("stroke-black")
+      end
+    end
+  end
+
+  describe "pollution_labels" do
+    let(:forecasts) {
+      [
+        FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, :low)),
+        FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, :high))
+      ]
+    }
+
+    it "returns the labels of the air pollution predictions" do
+      expect(component.send(:pollution_labels)).to eq([["LOW", "HIGH"]])
+    end
+  end
+
+  describe "highest_alert" do
+    let(:forecasts) {
+      [
+        FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, :low)),
+        FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, air_pollution_level))
+      ]
+    }
+
+    context "when the highest alert is VERY HIGH" do
+      let(:air_pollution_level) { :very_high }
+
+      it "returns VERY HIGH" do
+        expect(component.send(:highest_alert)).to eq("VERY HIGH")
+      end
+    end
+
+    context "when the highest alert is HIGH" do
+      let(:air_pollution_level) { :high }
+
+      it "returns LOW" do
+        expect(component.send(:highest_alert)).to eq("HIGH")
+      end
+    end
+  end
+end

--- a/spec/features/visitors/view_alerts_page_spec.rb
+++ b/spec/features/visitors/view_alerts_page_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.feature "Air quality alerts page" do
+  describe "Visit the air quality alerts page" do
+    context "when there are no alerts" do
+      it "should display a message" do
+        visit alerts_path
+        expect(page).to have_content "No alerts"
+      end
+    end
+
+    context "when there are alerts" do
+      before do
+        forecasts = [
+          Fixtures::API.zone_forecast(
+            day: :today,
+            air_pollution_status: :high
+          ),
+          Fixtures::API.zone_forecast(
+            day: :tomorrow,
+            air_pollution_status: :moderate,
+            daqi_value: 4
+          ),
+          Fixtures::API.zone_forecast(
+            day: :day_after_tomorrow,
+            air_pollution_status: :very_high,
+            daqi_value: 10
+          )
+        ]
+        HttpStubs.stub_cerc_api_with(forecasts)
+      end
+
+      it "should display the alerts" do
+        visit alerts_path
+        expect(page).to have_content "High"
+        expect(page).to have_content "Moderate"
+        expect(page).to have_content "Very high"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
This PR adds a new air quality alerts page, and an air quality alert banner on all pages, per the Figma design. The banner is implemented as a view component.

Trello: https://trello.com/c/iulqfRC0/142-air-quality-alerts

## Screenshots of UI changes

### Page
<img width="1159" alt="image" src="https://github.com/user-attachments/assets/88490c41-9c8c-4e53-901e-49070f54fda9">

<img width="1163" alt="image" src="https://github.com/user-attachments/assets/a992d5df-367f-47ea-9ded-3316bd837bb3">


### Banner
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/bba8ae27-f9bf-4434-a634-adb60d7900c5">

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/d4bceb66-f56b-472b-bda4-e9a5b90e59fd">

