### PR TITLE
Add ability to show dummy forecasts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "terser"
 gem "httparty"
 gem "view_component"
 gem "seed-fu"
+gem "factory_bot_rails"
 
 group :development do
   gem "better_errors"
@@ -39,7 +40,6 @@ group :development, :test do
   gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv"
-  gem "factory_bot_rails"
   gem "faker"
   gem "rspec-rails"
   gem "rails-controller-testing"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :dummy_forecast
+
   def health_check
     render json: {
       rails: "OK",
       git_sha: ENV.fetch("CURRENT_GIT_SHA", "UNKNOWN"),
       built_at: ENV.fetch("TIME_OF_BUILD", "UNKNOWN")
     }, status: :ok
+  end
+
+  def dummy_forecast
+    ENV["DUMMY_FORECAST"] = params[:dummy]
   end
 end

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -41,6 +41,7 @@ class ForecastsController < ApplicationController
     @date = date
     @day = @date ? day_from_date(@date) : day
     @pollutant = pollutant
+    @dummy = ENV.fetch("DUMMY_FORECAST", nil)
   end
 
   private

--- a/app/services/cerc_forecast_service.rb
+++ b/app/services/cerc_forecast_service.rb
@@ -4,8 +4,10 @@ class CercForecastService
       refresh_cache if CachedForecast.stale?
 
       if zone.nil?
+        return [dummy_forecasts] if dummy_forecast?
         CachedForecast.latest_for_all_zones
       else
+        return dummy_forecasts if dummy_forecast?
         CachedForecast.latest_for(zone)
       end
     end
@@ -21,6 +23,28 @@ class CercForecastService
           zone_forecasts(zone, obtained_at: obtained_at)
         )
       end
+    end
+
+    def dummy_forecast?
+      ENV.fetch("DUMMY_FORECAST", nil).present?
+    end
+
+    def dummy_forecasts
+      forecast_sets = {
+        1 => [ # A high, moderate, and low air pollution forecast
+          FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, :high), date: Date.today),
+          FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, :moderate), date: Date.tomorrow),
+          FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, :low), date: Date.tomorrow + 1.day)
+        ],
+        2 => [ # High UV, moderate pollen, and extreme temperature forecast
+          FactoryBot.build(:forecast, uv: 6, date: Date.today),
+          FactoryBot.build(:forecast, pollen: 8, date: Date.tomorrow),
+          FactoryBot.build(:forecast, temperature: {min: -10, max: 40}, date: Date.tomorrow + 1.day)
+        ]
+      }
+
+      set_number = (ENV.fetch("DUMMY_FORECAST").presence || 1).to_i
+      FactoryBot.build(:cached_forecast, data: forecast_sets[set_number])
     end
 
     def zone_forecasts(zone, obtained_at: Time.current)

--- a/app/views/forecasts/_forecast_form.html.erb
+++ b/app/views/forecasts/_forecast_form.html.erb
@@ -4,4 +4,5 @@
   <%= hidden_field_tag :lat, @map_lat, data: { "map-target": "latField" } %>
   <%= hidden_field_tag :lng, @map_lng, data: { "map-target": "lngField" } %>
   <%= hidden_field_tag :zoom, @map_zoom, data: { "map-target": "zoomField" } %>
+  <%= hidden_field_tag :dummy, @dummy %>
 <% end %>

--- a/spec/services/cerc_forecast_service_spec.rb
+++ b/spec/services/cerc_forecast_service_spec.rb
@@ -54,6 +54,18 @@ RSpec.describe CercForecastService do
         expect(CercForecastService.latest_forecasts).to match_array([latest_forecast_from_cache])
       end
     end
+
+    context "when the DUMMY_FORECAST environment variable is set" do
+      before do
+        allow(CachedForecast).to receive(:stale?).and_return(false)
+      end
+
+      it "returns the dummy forecasts" do
+        ClimateControl.modify DUMMY_FORECAST: "1" do
+          expect(CercForecastService.latest_forecasts(zone).data.first.air_pollution[:label]).to eq("HIGH")
+        end
+      end
+    end
   end
 
   describe "::zone_forecasts" do


### PR DESCRIPTION
## Context
It's useful to be able to make the app show dummy forecasts so that we can see what it looks like in different conditions during development and testing.

Trello: https://trello.com/c/utLRuOCD/75-create-a-fake-cerc-api

## Changes in this PR

This commit adds an environmental variable flag controlled by a url query parameter `dummy`. If the parameter is set to 1 or 2, the corresponding dummy forecast will be used instead of the real forecast. When the parameter is not set there is no impact.

We use FactoryBot to create the dummy forecast is the same way that we would for a test.