### PR TITLE
Replace sass-rails gem with dart-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.3.6"
 
 gem "active_link_to", "~> 1.0" # Active links with CSS classes
 gem "bootsnap", ">= 1.1.0", require: false
+gem "dartsass-rails", "~> 0.5.1"
 gem "high_voltage"
 gem "jbuilder", "~> 2.11"
 gem "lograge", "~> 0.12"
@@ -15,7 +16,7 @@ gem "pry-byebug"
 gem "puma", "~> 6.4"
 gem "rollbar"
 gem "rails", "~> 7.2"
-gem "sass-rails", "~> 6.0"
+gem "sprockets-rails", "~> 3.5"
 gem "turbo-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "terser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,9 @@ GEM
     cuprite (0.15.1)
       capybara (~> 3.0)
       ferrum (~> 0.15.0)
+    dartsass-rails (0.5.1)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     date (3.3.4)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
@@ -148,6 +151,15 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.29.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.29.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.29.1-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
     hashdiff (1.1.1)
     high_voltage (4.0.0)
     htmlbeautifier (1.4.3)
@@ -323,16 +335,12 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.82.0-arm64-darwin)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.82.0-x86_64-darwin)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.82.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.28)
     securerandom (0.4.0)
     seed-fu (2.3.9)
       activerecord (>= 3.1)
@@ -357,9 +365,9 @@ GEM
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
+    sprockets-rails (3.5.2)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     standard (1.42.1)
       language_server-protocol (~> 3.17.0.2)
@@ -379,7 +387,6 @@ GEM
     terser (1.2.4)
       execjs (>= 0.3.0, < 3)
     thor (1.3.2)
-    tilt (2.3.0)
     timeout (0.4.1)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
@@ -432,6 +439,7 @@ DEPENDENCIES
   climate_control
   cssbundling-rails (~> 1.4)
   cuprite
+  dartsass-rails (~> 0.5.1)
   dotenv
   factory_bot_rails
   faker
@@ -452,13 +460,13 @@ DEPENDENCIES
   rails_layout
   rollbar
   rspec-rails
-  sass-rails (~> 6.0)
   seed-fu
   selenium-webdriver
   shoulda-matchers (~> 6.0)
   simplecov
   spring
   spring-commands-rspec
+  sprockets-rails (~> 3.5)
   standard
   stimulus-rails
   terser

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
 css: yarn build:css --watch
 js: yarn build --watch
+css: bin/rails dartsass:watch

--- a/app/assets/stylesheets/application.tailwind.css.scss
+++ b/app/assets/stylesheets/application.tailwind.css.scss
@@ -1,17 +1,17 @@
-@import "leaflet/dist/leaflet.css";
-@import "@maptiler/geocoding-control/style.css"; /* Geocoding (search) control */
-@import "leaflet.locatecontrol/dist/L.Control.Locate.min.css"; /* Geolocation button */
-@import "leaflet.fullscreen/Control.FullScreen.css"; /* Fullscreen button */
-@import "header.scss";
-@import "air-quality-alert-banner.scss";
-@import "forecast-page.scss";
-@import "health-advice-page.scss";
-@import "air-quality-alerts-page.scss";
-@import "map.scss";
-@import "daqi-levels.scss";
-@import "share.scss";
-@import "text-block.scss";
-@import "footer.scss";
+@use "leaflet/dist/leaflet.css";
+@use "@maptiler/geocoding-control/style.css"; /* Geocoding (search) control */
+@use "leaflet.locatecontrol/dist/L.Control.Locate.min.css"; /* Geolocation button */
+@use "leaflet.fullscreen/Control.FullScreen.css"; /* Fullscreen button */
+@use "header.scss";
+@use "air-quality-alert-banner.scss";
+@use "forecast-page.scss";
+@use "health-advice-page.scss";
+@use "air-quality-alerts-page.scss";
+@use "map.scss";
+@use "daqi-levels.scss";
+@use "shar.scsse";
+@use "text-block.scss";
+@use "footer.scss";
 
 @tailwind base;
 @tailwind components;

--- a/doc/architecture/decisions/0012-use-open-source-mapping-tools.md
+++ b/doc/architecture/decisions/0012-use-open-source-mapping-tools.md
@@ -9,8 +9,8 @@ Accepted
 ## Context
 
 Representing air pollution and other environment characteristics visually on a
-map is an important part of the UX in airTEXT. The [original
-airTEXT implementation][] and the [sister project for York][] both used Google Maps.
+map is an important part of the UX in airTEXT. The [original airTEXT
+implementation][] and the [sister project for York][] both used Google Maps.
 
 However, using this commercial product with its fundamental data privacy
 uncertainties is not necessary and should be challenged.

--- a/doc/architecture/decisions/0014-cache-cerc-api-responses-using-postgres.md
+++ b/doc/architecture/decisions/0014-cache-cerc-api-responses-using-postgres.md
@@ -8,10 +8,10 @@ Accepted
 
 ## Context
 
-The airTEXT service we're building obtains forecasts from [CERC's API][]. These forecasts
-are available for a particular day, from 50 areas or "zones". The forecasts are updated
-occasionally during the day (we're not clear as to the exact schedule of updates).
-A single request to the CERC API can be for:
+The airTEXT service we're building obtains forecasts from [CERC's API][]. These
+forecasts are available for a particular day, from 50 areas or "zones". The
+forecasts are updated occasionally during the day (we're not clear as to the
+exact schedule of updates). A single request to the CERC API can be for:
 
 - a particular zone or for all zones
 

--- a/doc/terminology.md
+++ b/doc/terminology.md
@@ -24,8 +24,8 @@ environmental **`predictions`**:
 - Wind
 - Rain
 
-Each **prediction** has an **`DAQI level`**. This [DAQI (Daily Air
-Quality Index)][] scoring uses the range 1-10:
+Each **prediction** has an **`DAQI level`**. This [DAQI (Daily Air Quality
+Index)][] scoring uses the range 1-10:
 
 - low (1-3)
 - moderate (4-6)


### PR DESCRIPTION
## Context
The sass-rails gem has been deprecated, and dart-rails is its replacement.

## Changes in this PR
This PR replaces the sass-rails gem with the dart-rails gem.

There is also some inexplicable linting of some docs.