### PR TITLE
Improve VerificationCode security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,6 @@ CERC_SUBSCRIBE_API_HOST_URL=https://cerc.example.com
 CERC_SUBSCRIBE_API_KEY=SECRET-API-KEY
 
 MAPTILER_API_KEY=SECRET-DEV-KEY-FROM-MAPTILER # or prod key limited to Heroku origin
+
+# Secret key used in hashing of emails and phone numbers for verification tokens
+SECRET_KEY=SECRET-KEY

--- a/.env.test
+++ b/.env.test
@@ -16,3 +16,6 @@ CERC_SUBSCRIBE_API_HOST_URL=https://cerc.example.com
 CERC_SUBSCRIBE_API_KEY=SECRET-API-KEY
 
 MAPTILER_API_KEY=TOPSECRET
+
+# Secret key used in hashing of emails and phone numbers for verification tokens
+SECRET_KEY=SECRET-KEY

--- a/app/models/verification_code.rb
+++ b/app/models/verification_code.rb
@@ -13,6 +13,10 @@ class VerificationCode < ApplicationRecord
       })
     end
 
+    def remove_expired
+      where("expires_at < ?", Time.current).destroy_all
+    end
+
     def verify(inputted_code, inputted_target)
       return false if inputted_code.blank? || inputted_target.blank?
 

--- a/app/models/verification_code.rb
+++ b/app/models/verification_code.rb
@@ -32,7 +32,7 @@ class VerificationCode < ApplicationRecord
     end
 
     def digest(target)
-      Digest::SHA256.hexdigest(target)
+      OpenSSL::HMAC.hexdigest("SHA256", ENV.fetch("SECRET_KEY"), target)
     end
   end
 end

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,1 +1,5 @@
 task default: %i[standard spec] if Rails.env.test? || Rails.env.development?
+
+task remove_expired_verification_codes: :environment do
+  VerificationCode.remove_expired
+end

--- a/spec/models/verification_code_spec.rb
+++ b/spec/models/verification_code_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe VerificationCode do
+  describe "#expired?" do
+    let(:verification_code) { VerificationCode.new(expires_at: expires_at) }
+
+    context "when expires_at is in the past" do
+      let(:expires_at) { 1.hour.ago }
+
+      it "returns true" do
+        expect(verification_code.expired?).to be_truthy
+      end
+    end
+
+    context "when expires_at is in the future" do
+      let(:expires_at) { 1.hour.from_now }
+
+      it "returns false" do
+        expect(verification_code.expired?).to be_falsey
+      end
+    end
+  end
+
+  describe ".generate" do
+    it "creates a new verification code for the target that expires in 1 hour" do
+      expect { VerificationCode.generate("target") }.to change { VerificationCode.count }.by(1)
+      expect(VerificationCode.last.target).to eq(VerificationCode.digest("target"))
+      expect(VerificationCode.last.expires_at).to be_within(1.second).of(1.hour.from_now)
+    end
+  end
+
+  describe ".remove_expired" do
+    it "removes expired verification codes" do
+      VerificationCode.create!(expires_at: 1.hour.ago)
+      VerificationCode.create!(expires_at: 1.hour.from_now)
+
+      expect { VerificationCode.remove_expired }.to change { VerificationCode.count }.by(-1)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,9 @@
 
 require "simplecov"
 SimpleCov.minimum_coverage 99
-SimpleCov.start "rails"
+SimpleCov.start "rails" do
+  add_filter "/lib/tasks/"
+end
 
 require "webmock/rspec"
 WebMock.disable_net_connect!(allow_localhost: true, allow: [


### PR DESCRIPTION
## Context
VerificationCode records contain a hash of the email address or phone number they are for. We currently use a basic digest algorithm, and have no mechanism for removing expired records.

## Changes in this PR
This PR updates the algorithm to be more secure using a secret key, and adds a method and rake task to remove all expired verification codes.