### PR TITLE
Define database names in config rather than ENVs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,6 @@
 ROLLBAR_ACCESS_TOKEN=ROLLBAR_ACCESS_TOKEN
 ROLLBAR_ENV=development
 
-DATABASE_URL=postgres://postgres@localhost:5432/air-text-development
-
 # TODO: Replace `example.com` with the canonical hostname of the app
 CANONICAL_HOSTNAME=example.com
 

--- a/.env.test
+++ b/.env.test
@@ -5,9 +5,6 @@
 #
 # Reference=https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
-DATABASE_URL=postgres://postgres@localhost:5432/air-text-test
-HOSTNAME=localhost
-
 CERC_FORECAST_API_HOST_URL=https://cerc.example.com
 CERC_FORECAST_API_KEY=SECRET-API-KEY
 CERC_FORECAST_API_CACHE_LIMIT_MINS=60

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,9 +6,11 @@ default: &default
   pool: <%= Integer(ENV.fetch('RAILS_MAX_THREADS') { 5 }) %>
 
 development:
+  database: air-text_development
   <<: *default
 
 test:
+  database: air-text_test
   <<: *default
 
 production:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,8 +45,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_05_174315) do
     t.integer "cerc_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.float "latitude"
-    t.float "longitude"
     t.uuid "zone_group_id"
     t.index ["cerc_id"], name: "index_zones_on_cerc_id", unique: true
     t.index ["zone_group_id"], name: "index_zones_on_zone_group_id"


### PR DESCRIPTION
## Context
Currently the database names are defined in environmental variables. This is fine, but causes some problems when using database tools like Parity.

## Changes in this PR
This PR moves the database names into the database config file.

It also cleans up the schema.
