### PR TITLE
Handle missing forecasts

### DIFF
--- a/app/components/day_tab_component.html.erb
+++ b/app/components/day_tab_component.html.erb
@@ -1,7 +1,6 @@
-<%= tag.div class: "tab #{@day} #{@active ? 'active' : 'inactive'} #{@forecast.air_pollution[:label] == 'LOW' ? 'low' : daqi_indicator_colour_class}",
+<%= tag.div class: "tab #{@active ? 'active' : 'inactive'} #{@forecast.air_pollution[:label] == 'LOW' ? 'low' : daqi_indicator_colour_class}",
   data: {
     date: @forecast.date.to_s,
-    day: @day,
     action: "click->forecast#changeDay",
   } do
   %>

--- a/app/components/day_tab_component.rb
+++ b/app/components/day_tab_component.rb
@@ -1,8 +1,7 @@
 class DayTabComponent < ViewComponent::Base
-  def initialize(forecast:, day:, active: false)
+  def initialize(forecast:, active_date:)
     @forecast = forecast
-    @day = day
-    @active = active
+    @active = active_date == forecast.date
   end
 
   def daqi_indicator_colour_class

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -39,7 +39,7 @@ class ForecastsController < ApplicationController
   def load_options
     @zone = zone
     @date = date
-    @day = @date ? day_from_date(@date) : day
+    @day = @date ? day_from_date(@date) : "today"
     @pollutant = pollutant
     @dummy = ENV.fetch("DUMMY_FORECAST", nil)
   end
@@ -74,15 +74,11 @@ class ForecastsController < ApplicationController
   end
 
   def date
-    Date.parse(params.fetch("date")) if params[:date].present?
+    return Date.parse(params.fetch("date")) if params[:date].present?
+
+    Date.today
   rescue ArgumentError
     Date.today # default to today
-  end
-
-  def day
-    return params.fetch("day") if %w[today tomorrow day_after_tomorrow].include?(params.dig("day"))
-
-    "today" # default to today
   end
 
   def pollutant

--- a/app/models/cached_forecast.rb
+++ b/app/models/cached_forecast.rb
@@ -9,6 +9,31 @@ class CachedForecast < ApplicationRecord
       .order(:zone_id, obtained_at: :desc)
   }
 
+  validates :obtained_at, :zone, :data, presence: true
+  validate :data_is_complete?
+
+  def data_is_complete?
+    errors.add(:data, "must be an array of three forecasts") unless data.is_a?(Array) && data.size == 3
+
+    data&.each do |forecast|
+      errors.add(:data, "forecasted_at must be a date") unless forecast.air_pollution[:forecasted_at].is_a?(Time)
+
+      %i[no2 pm10 pm2_5 o3 total].each do |pollutant|
+        errors.add(:data, "#{pollutant} must be an integer") unless forecast.air_pollution[pollutant].is_a?(Integer)
+      end
+
+      errors.add(:data, "label must be one of the expected values") unless Forecast::AIR_POLLUTION_LABELS.include?(forecast.air_pollution[:label])
+
+      %i[uv pollen].each do |pollutant|
+        errors.add(:data, "#{pollutant} must be an integer") unless forecast.send(pollutant).is_a?(Integer)
+      end
+
+      %i[min max].each do |temp|
+        errors.add(:data, "temperature.#{temp} must be a number") unless forecast.temperature[temp].is_a?(Numeric)
+      end
+    end
+  end
+
   def pollutant_forecasts(pollutant)
     data.map { |f| f.air_pollution[pollutant.downcase.to_sym] }
   end
@@ -23,10 +48,12 @@ class CachedForecast < ApplicationRecord
   end
 
   def self.store(built_forecasts)
-    create(
+    create!(
       zone: Zone.find_by(cerc_id: built_forecasts.first.zone[:id]),
       obtained_at: built_forecasts.first.obtained_at,
       data: built_forecasts
     )
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("Failed to store forecast: #{e.message}")
   end
 end

--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -3,6 +3,13 @@ class Forecast
 
   attr_accessor :obtained_at, :date, :zone, :air_pollution, :uv, :pollen, :temperature
 
+  AIR_POLLUTION_LABELS = [
+    "LOW",
+    "MODERATE",
+    "HIGH",
+    "VERY HIGH"
+  ]
+
   def air_quality_alert?
     air_pollution[:label] != "LOW"
   end

--- a/app/views/forecasts/_forecast_tabs.html.erb
+++ b/app/views/forecasts/_forecast_tabs.html.erb
@@ -1,8 +1,8 @@
 <turbo-frame id="forecast-tabs-frame">
   <h3 class="h3 mb-2"> Air pollution forecast for <%= @zone[:name] %></h3>
   <div class="tabs">
-    <%= render(DayTabComponent.new(forecast: @forecasts.first, day: 'today', active: @day == 'today')) %>
-    <%= render(DayTabComponent.new(forecast: @forecasts.second, day: 'tomorrow', active: @day == 'tomorrow')) %>
-    <%= render(DayTabComponent.new(forecast: @forecasts.third, day: 'day_after_tomorrow', active: @day == 'day_after_tomorrow')) %>
+    <%= render(DayTabComponent.new(forecast: @forecasts.first, active_date: @date)) %>
+    <%= render(DayTabComponent.new(forecast: @forecasts.second, active_date: @date)) %>
+    <%= render(DayTabComponent.new(forecast: @forecasts.third, active_date: @date)) %>
   </div>
 </turbo-frame>

--- a/spec/components/day_tab_component_spec.rb
+++ b/spec/components/day_tab_component_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe DayTabComponent, type: :component do
   describe "daqi_indicator_colour_class" do
     let(:component) {
-      DayTabComponent.new(forecast: FactoryBot.build(:forecast, air_pollution_level: air_pollution_level), day: :today)
+      DayTabComponent.new(forecast: FactoryBot.build(:forecast, air_pollution_level: air_pollution_level), active_date: Date.today)
     }
 
     context "when the air pollution level is 1" do
@@ -90,7 +90,7 @@ RSpec.describe DayTabComponent, type: :component do
   describe "icon_stroke_colour_class" do
     let(:component) {
       forecast = FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, level))
-      DayTabComponent.new(forecast: forecast, day: :today)
+      DayTabComponent.new(forecast: forecast, active_date: Date.today)
     }
 
     context "when the air pollution label is _Very high_" do

--- a/spec/controllers/forecasts_controller_spec.rb
+++ b/spec/controllers/forecasts_controller_spec.rb
@@ -39,28 +39,6 @@ RSpec.describe ForecastsController do
       expect(response).to render_template("show")
     end
 
-    context "when a _day_ parameter is received" do
-      before do
-        get :show, params: {day: day}
-      end
-
-      context "when a recognised _day_ parameter is received" do
-        let(:day) { "tomorrow" }
-
-        it "shows the forecast for the given day" do
-          expect(assigns(:day_forecast)).to eq(forecasts.data.second)
-        end
-      end
-
-      context "when an unrecognised _day_ parameter is received" do
-        let(:day) { "invalid" }
-
-        it "shows today's forecast" do
-          expect(assigns(:day_forecast)).to eq(forecasts.data.first)
-        end
-      end
-    end
-
     context "when a _date_ parameter is received" do
       before do
         get :show, params: {date: date.to_s}

--- a/spec/features/visitors/view_air_quality_alerts_spec.rb
+++ b/spec/features/visitors/view_air_quality_alerts_spec.rb
@@ -24,8 +24,9 @@ RSpec.feature "Forecasts page - air quality alerts" do
   describe "View air quality alert for today" do
     it "shows an air quality alert of high for today" do
       visit forecast_path
+      tab_selector = ".tab[data-date='#{Date.today}']"
 
-      within(".today[data-date='#{Date.today}']") do
+      within(tab_selector) do
         expect_to_see_alert_level("High")
       end
       within(".alert-guidance") do
@@ -37,15 +38,16 @@ RSpec.feature "Forecasts page - air quality alerts" do
   describe "View air quality alert for tomorrow", js: true do
     it "shows an air quality alert of moderate for tomorrow" do
       visit forecast_path
-      switch_to_tab_for(:tomorrow)
+      tab_selector = ".tab[data-date='#{Date.tomorrow}']"
+      find(tab_selector).trigger("click")
 
-      within(".tomorrow[data-date='#{Date.tomorrow}']") do
+      within(tab_selector) do
         expect_to_see_alert_level("Moderate")
       end
       within(".alert-guidance") do
         expect_to_see_guidance_for(:moderate)
       end
-      expect(page).to have_css(".tab.tomorrow.active")
+      expect(page).to have_css("#{tab_selector}.active")
       expect(page).not_to have_css(".tab.day_after_tomorrow.active")
     end
   end
@@ -53,15 +55,16 @@ RSpec.feature "Forecasts page - air quality alerts" do
   describe "View air quality alert for the day after tomorrow", js: true do
     it "shows an air quality alert of very high for the day after tomorrow" do
       visit forecast_path
-      switch_to_tab_for(:day_after_tomorrow)
+      tab_selector = ".tab[data-date='#{Date.tomorrow + 1.day}']"
+      find(tab_selector).trigger("click")
 
-      within(".day_after_tomorrow[data-date='#{Date.tomorrow + 1.day}']") do
+      within(tab_selector) do
         expect_to_see_alert_level("Very high")
       end
       within(".alert-guidance") do
         expect_to_see_guidance_for(:very_high)
       end
-      expect(page).to have_css(".tab.day_after_tomorrow.active")
+      expect(page).to have_css("#{tab_selector}.active")
       expect(page).not_to have_css(".tab.tomorrow.active")
     end
   end

--- a/spec/features/visitors/view_forecasts_spec.rb
+++ b/spec/features/visitors/view_forecasts_spec.rb
@@ -4,6 +4,10 @@ RSpec.feature "Forecasts page" do
   include Features::ForecastPageHelper
 
   describe "Viewing forecasts" do
+    tab_selector_today = ".tab[data-date='#{Date.today}']"
+    tab_selector_tomorrow = ".tab[data-date='#{Date.tomorrow}']"
+    tab_selector_day_after_tomorrow = ".tab[data-date='#{Date.tomorrow + 1.day}']"
+
     describe "Viewing forecasts for 3 days" do
       before do
         forecasts = [
@@ -51,13 +55,13 @@ RSpec.feature "Forecasts page" do
         expect(page).to have_content("Air quality forecast")
 
         # Today tab is active
-        expect(page).to have_css(".tab.today.active")
+        expect(page).to have_css("#{tab_selector_today}.active")
 
-        expect(page).to have_css(".tab.tomorrow.inactive")
-        expect(page).to have_css(".tab.day_after_tomorrow.inactive")
+        expect(page).to have_css("#{tab_selector_tomorrow}.inactive")
+        expect(page).to have_css("#{tab_selector_day_after_tomorrow}.inactive")
 
-        expect(page).not_to have_css(".tab.tomorrow.active")
-        expect(page).not_to have_css(".tab.day_after_tomorrow.active")
+        expect(page).not_to have_css("#{tab_selector_tomorrow}.active")
+        expect(page).not_to have_css("#{tab_selector_day_after_tomorrow}.active")
 
         # Air pollution status for each day
         expect_air_pollution_prediction(day: :today, value: :high)
@@ -86,16 +90,19 @@ RSpec.feature "Forecasts page" do
         ##
 
         visit forecast_path
-        switch_to_tab_for(:tomorrow)
+        tab_selector_today = ".tab[data-date='#{Date.today}']"
+        tab_selector_tomorrow = ".tab[data-date='#{Date.tomorrow}']"
+        tab_selector_day_after_tomorrow = ".tab[data-date='#{Date.tomorrow + 1.day}']"
+        find(tab_selector_tomorrow).trigger("click")
 
         # See that the tomorrow tab is active
-        expect(page).to have_css(".tab.tomorrow.active")
+        expect(page).to have_css("#{tab_selector_tomorrow}.active")
 
-        expect(page).to have_css(".tab.today.inactive")
-        expect(page).to have_css(".tab.day_after_tomorrow.inactive")
+        expect(page).to have_css("#{tab_selector_today}.inactive")
+        expect(page).to have_css("#{tab_selector_day_after_tomorrow}.inactive")
 
-        expect(page).not_to have_css(".tab.today.active")
-        expect(page).not_to have_css(".tab.day_after_tomorrow.active")
+        expect(page).not_to have_css("#{tab_selector_today}.active")
+        expect(page).not_to have_css("#{tab_selector_day_after_tomorrow}.active")
 
         # Predicted UV level for tomorrow
         expect_prediction(category: :uv, level: :moderate)
@@ -119,16 +126,16 @@ RSpec.feature "Forecasts page" do
         ##
 
         visit forecast_path
-        switch_to_tab_for(:day_after_tomorrow)
+        find(tab_selector_day_after_tomorrow).trigger("click")
 
         # See that the day after tomorrow tab is active
-        expect(page).to have_css(".tab.day_after_tomorrow.active")
+        expect(page).to have_css("#{tab_selector_day_after_tomorrow}.active")
 
-        expect(page).to have_css(".tab.today.inactive")
-        expect(page).to have_css(".tab.tomorrow.inactive")
+        expect(page).to have_css("#{tab_selector_today}.inactive")
+        expect(page).to have_css("#{tab_selector_tomorrow}.inactive")
 
-        expect(page).not_to have_css(".tab.today.active")
-        expect(page).not_to have_css(".tab.tomorrow.active")
+        expect(page).not_to have_css("#{tab_selector_today}.active")
+        expect(page).not_to have_css("#{tab_selector_tomorrow}.active")
 
         # Predicted UV level for the day after tomorrow
         expect_prediction(category: :uv, level: :high)

--- a/spec/fixtures/api/forecasts.rb
+++ b/spec/fixtures/api/forecasts.rb
@@ -13,7 +13,7 @@ module Fixtures
 
       def zone_object(zone_id: 55, forecasts: [])
         {
-          "forecasts" => forecasts.presence || [zone_forecast],
+          "forecasts" => forecasts.presence || [zone_forecast(day: :today), zone_forecast(day: :tomorrow), zone_forecast(day: :day_after_tomorrow)],
           "zone_id" => zone_id,
           "zone_name" => "Central London",
           "zone_type" => 1

--- a/spec/models/cached_forecast_spec.rb
+++ b/spec/models/cached_forecast_spec.rb
@@ -4,6 +4,56 @@ RSpec.describe CachedForecast do
     ClimateControl.modify(env_vars) { example.run }
   end
 
+  describe "validations" do
+    it { should validate_presence_of(:obtained_at) }
+    it { should validate_presence_of(:zone) }
+    it { should validate_presence_of(:data) }
+
+    it "validates that #data is an array of three forecasts" do
+      cached_forecast = FactoryBot.build(:cached_forecast, data: FactoryBot.build_list(:forecast, 2))
+
+      expect(cached_forecast).not_to be_valid
+      expect(cached_forecast.errors[:data]).to include("must be an array of three forecasts")
+    end
+
+    it "validates that each forecast in #data has a :forecasted_at date" do
+      cached_forecast = FactoryBot.build(:cached_forecast, data: [
+        FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, forecasted_at: "2024-10-21"))
+      ])
+
+      expect(cached_forecast).not_to be_valid
+      expect(cached_forecast.errors[:data]).to include("forecasted_at must be a date")
+    end
+
+    it "validates that each forecast in #data has integer values for air pollution" do
+      cached_forecast = FactoryBot.build(:cached_forecast, data: [
+        FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, no2: "1"))
+      ])
+
+      expect(cached_forecast).not_to be_valid
+      expect(cached_forecast.errors[:data]).to include("no2 must be an integer")
+    end
+
+    it "validates that each forecast in #data has a valid :label" do
+      cached_forecast = FactoryBot.build(:cached_forecast, data: [
+        FactoryBot.build(:forecast, air_pollution: FactoryBot.build(:air_pollution_prediction, label: "invalid"))
+      ])
+
+      expect(cached_forecast).not_to be_valid
+      expect(cached_forecast.errors[:data]).to include("label must be one of the expected values")
+    end
+
+    it "validates that each forecast in #data has integer values for UV and pollen" do
+      cached_forecast = FactoryBot.build(:cached_forecast, data: [
+        FactoryBot.build(:forecast, uv: "1", pollen: "2")
+      ])
+
+      expect(cached_forecast).not_to be_valid
+      expect(cached_forecast.errors[:data]).to include("uv must be an integer")
+      expect(cached_forecast.errors[:data]).to include("pollen must be an integer")
+    end
+  end
+
   describe "::last" do
     let!(:first) { FactoryBot.create(:cached_forecast, obtained_at: Time.current - 2.days) }
     let!(:last) { FactoryBot.create(:cached_forecast, obtained_at: Time.current) }

--- a/spec/support/features/forecast_page_helper.rb
+++ b/spec/support/features/forecast_page_helper.rb
@@ -1,16 +1,5 @@
 module Features
   module ForecastPageHelper
-    def switch_to_tab_for(day)
-      case day
-      when :tomorrow
-        find(".tab.tomorrow").trigger("click")
-      when :day_after_tomorrow
-        find(".tab.day_after_tomorrow").trigger("click")
-      else
-        raise "day: #{day} not expected"
-      end
-    end
-
     def expect_to_see_alert_date_for(day)
       date = case day
       when :today


### PR DESCRIPTION
## Context
Sometimes CERC doesn’t provide a forecast at the expected time, or the forecast returned by the CERC API is missing essential information. In those situations we don't want to store it and instead we want to fall back to the most recent forecast.

Trello: https://trello.com/c/t1ikfYcX/145-make-site-resilient-to-missing-forecasts

## Changes in this PR
This PR adds validation to ensure the forecast is correct before storing it, and changes the logic around with tab should be shown as active so that rather than assuming that the first tab always shows today's forecast, we check and switch to the tab which is actually for today.