### PR TITLE
Move Faker gem so that it can be used in production for dummy forecasts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "httparty"
 gem "view_component"
 gem "seed-fu"
 gem "factory_bot_rails"
+gem "faker"
 gem "wicked" # for multi-step forms
 
 group :development do
@@ -42,7 +43,6 @@ group :development, :test do
   gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv"
-  gem "faker"
   gem "rspec-rails"
   gem "rails-controller-testing"
   gem "standard"


### PR DESCRIPTION
## Context
In #158 we added the ability to show dummy forecasts. This requires the Faker gem which is not present in production, so currently throws an error.

## Changes in this PR
This PR moves the Faker gem to production to support dummy forecasts.