### PR TITLE
Add notes about how to upgrade the Node and Ruby versions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 <!-- Do you need to update the changelog? -->
 
+## Context
+
 ## Changes in this PR
 
 ## Screenshots of UI changes

--- a/doc/upgrading-node.md
+++ b/doc/upgrading-node.md
@@ -1,0 +1,6 @@
+To upgrade Node, update the version number in the following files:
+- `.node-version`
+- `.tool-versions`
+- `package.json`
+
+If the major version changes, you will also need to update `Dockerfile`.

--- a/doc/upgrading-ruby.md
+++ b/doc/upgrading-ruby.md
@@ -1,0 +1,8 @@
+To upgrade Ruby, update the version number in the following files:
+- `.ruby-version`
+- `.tool-versions`
+- `Gemfile`
+- `Gemfile.lock`
+- `Dockerfile`
+
+Then run `bundle install` to update the gems.


### PR DESCRIPTION
## Changes in this PR
This PR adds docs to explain how to update the Ruby and Node versions because these are a bit fiddlier than most dependency updates.
