### PR TITLE
Verification code improvements

### DIFF
--- a/app/models/subscription_form.rb
+++ b/app/models/subscription_form.rb
@@ -24,9 +24,9 @@ class SubscriptionForm
   attribute :verification_code_voice_number
 
   before_validation do
-    self.verification_code_email = verification_code_email&.join
-    self.verification_code_sms_number = verification_code_sms_number&.join
-    self.verification_code_voice_number = verification_code_voice_number&.join
+    self.verification_code_email = verification_code_email&.join if verification_code_email.is_a?(Array)
+    self.verification_code_sms_number = verification_code_sms_number&.join if verification_code_sms_number.is_a?(Array)
+    self.verification_code_voice_number = verification_code_voice_number&.join if verification_code_voice_number.is_a?(Array)
   end
 
   validates :verification_code_email, presence: {message: "You must enter the verification code"}, if: -> { on_step?("email_verification") }

--- a/app/models/subscription_form.rb
+++ b/app/models/subscription_form.rb
@@ -29,12 +29,12 @@ class SubscriptionForm
     self.verification_code_voice_number = verification_code_voice_number&.join if verification_code_voice_number.is_a?(Array)
   end
 
-  validates :verification_code_email, presence: {message: "You must enter the verification code"}, if: -> { on_step?("email_verification") }
-  validate :verification_code_email_correct?, if: -> { on_step?("email_verification") }
-  validates :verification_code_sms_number, presence: {message: "You must enter the verification code"}, if: -> { on_step?("sms_number_verification") }
-  validate :verification_code_sms_correct?, if: -> { on_step?("sms_number_verification") }
-  validates :verification_code_voice_number, presence: {message: "You must enter the verification code"}, if: -> { on_step?("voice_number_verification") }
-  validate :verification_code_voice_correct?, if: -> { on_step?("voice_number_verification") }
+  validates :verification_code_email, presence: {message: "You must enter the verification code"}, if: -> { on_step?("email_verification") && verification_enabled? }
+  validate :verification_code_email_correct?, if: -> { on_step?("email_verification") && verification_enabled? }
+  validates :verification_code_sms_number, presence: {message: "You must enter the verification code"}, if: -> { on_step?("sms_number_verification") && verification_enabled? }
+  validate :verification_code_sms_correct?, if: -> { on_step?("sms_number_verification") && verification_enabled? }
+  validates :verification_code_voice_number, presence: {message: "You must enter the verification code"}, if: -> { on_step?("voice_number_verification") && verification_enabled? }
+  validate :verification_code_voice_correct?, if: -> { on_step?("voice_number_verification") && verification_enabled? }
 
   # zone_selection
   attribute :zone_search
@@ -129,6 +129,10 @@ class SubscriptionForm
 
   def one_contact_method_present?
     errors.add(:base, "You must select at least one contact method") unless receiving?(:email) || receiving?(:sms) || receiving?(:voice)
+  end
+
+  def verification_enabled?
+    ActiveModel::Type::Boolean.new.cast(ENV.fetch("VERIFICATION_ENABLED", true))
   end
 
   def verification_code_email_correct?

--- a/spec/features/visitors/subscribe_spec.rb
+++ b/spec/features/visitors/subscribe_spec.rb
@@ -158,6 +158,16 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
             expect(VerificationCode).to have_received(:generate).with(@subscription_form.email)
           end
         end
+
+        context "when verification is disabled" do
+          it "lets me proceed without entering a verification code" do
+            ClimateControl.modify VERIFICATION_ENABLED: "false" do
+              click_on "Next"
+
+              expect(page).to have_text("Your email is now verified")
+            end
+          end
+        end
       end
 
       describe "SMS number verification" do

--- a/spec/features/visitors/subscribe_spec.rb
+++ b/spec/features/visitors/subscribe_spec.rb
@@ -115,6 +115,23 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
           end
         end
 
+        context "when I enter an expired verification code" do
+          let(:code) { "123456" }
+
+          before do
+            allow(VerificationCode).to receive(:new_code).and_return(code)
+            allow_any_instance_of(VerificationCode).to receive(:expired?).and_return(true)
+            visit subscriptions_path(id: :email_verification)
+          end
+
+          it "shows an error" do
+            fill_in_verification_code(:email, code)
+            click_on "Next"
+
+            expect(page).to have_text("The verification code you entered is incorrect")
+          end
+        end
+
         context "when I don't enter a verification code" do
           it "shows an error" do
             click_on "Next"


### PR DESCRIPTION
## Changes in this PR
This PR:
- Adds an ENV called `VERIFICATION_ENABLED` which defaults to true, but can be used to disabled verification for manual testing purposes
- Adds a test for expired verification codes
- Fixes a bug related to processing verification codes