### PR TITLE
Fix site.webmanifest asset path

### DIFF
--- a/app/assets/images/site.webmanifest.erb
+++ b/app/assets/images/site.webmanifest.erb
@@ -3,13 +3,13 @@
   "short_name": "airTEXT",
   "icons": [
     {
-      "src": "/assets/favicons/web-app-manifest-192x192.png",
+      "src": "<%= asset_path('favicons/web-app-manifest-192x192.png') %>",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/assets/favicons/web-app-manifest-512x512.png",
+      "src": "<%= asset_path('favicons/web-app-manifest-512x512.png') %>",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= favicon_link_tag asset_path('favicons/favicon.svg'), rel: 'icon', type: 'image/svg+xml' %>
     <%= favicon_link_tag asset_path('favicons/favicon.ico'), rel: 'shortcut icon' %>
     <%= favicon_link_tag asset_path('favicons/apple-touch-icon.png'), rel: 'apple-touch-icon', sizes: '180x180' %>
-    <%= favicon_link_tag asset_path('site.webmanifest'), rel: 'manifest' %>
+    <%= favicon_link_tag asset_path('site.webmanifest.erb'), rel: 'manifest' %>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", media: 'all', "data-turbolinks-track" => "reload" %>
     <%= yield(:head) %>


### PR DESCRIPTION
## Context
We are getting errors in production because the icons defined in the `site.webmanifest` file cannot be found. In production the asset paths are dynamically generated, so we need to use an asset path helper, and that means changing the file to `.erb`.

## Changes in this PR
This PR should fix the asset paths in the `site.webmanifest` file.