### PR TITLE
Replace Cuprite with Selenium

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/continuous-integration/load-cache
       - name: Run RSpec and Simplecov
         run: |
-          docker compose -p complete-app -f docker-compose.ci.yml \
+          docker compose -p air-text-app -f docker-compose.ci.yml \
             run --name app_test test /bin/bash -c "bin/rails spec"
       - name: Shutdown containers
         run: docker compose -p app_test down && docker compose -p app_test rm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # Base
 # ------------------------------------------------------------------------------
-FROM ruby:3.4.1 as base
+FROM ruby:3.4.1 AS base
 LABEL org.opencontainers.image.authors="contact@dxw.com"
 
 RUN curl -L https://deb.nodesource.com/setup_22.x | bash -
@@ -16,12 +16,12 @@ RUN \
   build-essential \
   libpq-dev
 
-ENV APP_HOME /srv/app
-ENV DEPS_HOME /deps
+ENV APP_HOME=/srv/app
+ENV DEPS_HOME=/deps
 
 ARG RAILS_ENV
-ENV RAILS_ENV ${RAILS_ENV:-production}
-ENV NODE_ENV ${RAILS_ENV:-production}
+ENV RAILS_ENV=${RAILS_ENV:-production}
+ENV NODE_ENV=${RAILS_ENV:-production}
 
 # ------------------------------------------------------------------------------
 # Dependencies
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y yarn
 WORKDIR ${DEPS_HOME}
 
 # Install Ruby dependencies
-ENV BUNDLE_GEM_GROUPS ${RAILS_ENV}
+ENV BUNDLE_GEM_GROUPS=${RAILS_ENV}
 
 COPY Gemfile ${DEPS_HOME}/Gemfile
 COPY Gemfile.lock ${DEPS_HOME}/Gemfile.lock
@@ -107,8 +107,8 @@ RUN \
 ARG CURRENT_GIT_SHA
 ARG TIME_OF_BUILD
 
-ENV CURRENT_GIT_SHA ${CURRENT_GIT_SHA}
-ENV TIME_OF_BUILD ${TIME_OF_BUILD}
+ENV CURRENT_GIT_SHA=${CURRENT_GIT_SHA}
+ENV TIME_OF_BUILD=${TIME_OF_BUILD}
 
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
@@ -121,7 +121,7 @@ CMD ["bundle", "exec", "rails", "server"]
 # ------------------------------------------------------------------------------
 # Test
 # ------------------------------------------------------------------------------
-FROM web as test
+FROM web AS test
 
 RUN \
   apt-get update && \

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ end
 group :test do
   gem "capybara", ">= 2.15"
   gem "capybara-screenshot"
-  gem "cuprite"
   gem "launchy"
   gem "puffing-billy", "~> 4.0"
   gem "selenium-webdriver"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,9 +123,6 @@ GEM
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     csv (3.3.0)
-    cuprite (0.15.1)
-      capybara (~> 3.0)
-      ferrum (~> 0.15.0)
     dartsass-rails (0.5.1)
       railties (>= 6.0.0)
       sass-embedded (~> 1.63)
@@ -157,11 +154,6 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    ferrum (0.15)
-      addressable (~> 2.5)
-      concurrent-ruby (~> 1.1)
-      webrick (~> 1.7)
-      websocket-driver (~> 0.7)
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -429,7 +421,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.0)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -460,7 +451,6 @@ DEPENDENCIES
   capybara-screenshot
   climate_control
   cssbundling-rails (~> 1.4)
-  cuprite
   dartsass-rails (~> 0.5.1)
   dotenv
   factory_bot_rails

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,6 +16,7 @@ services:
       DATABASE_URL: postgres://postgres:password@test-db:5432/app-test
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       AUTOMATICALLY_FIX_LINTING: "true"
+      CI: "true"
     volumes:
       - .:/srv/app
     tty: true

--- a/spec/features/visitors/subscribe_spec.rb
+++ b/spec/features/visitors/subscribe_spec.rb
@@ -415,8 +415,6 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
           it "shows a message if no zones are found" do
             search_for_location("York")
 
-            find("#subscription_form_zone_search").trigger("change")
-
             within "#search-results" do
               expect(page).to have_text("No results found within the area covered by airTEXT")
             end
@@ -549,7 +547,6 @@ end
 
 def search_for_location(location)
   fill_in "subscription_form_zone_search", with: location
-  find("#subscription_form_zone_search").trigger("change")
 end
 
 def fill_form_up_to(step)

--- a/spec/features/visitors/subscribe_spec.rb
+++ b/spec/features/visitors/subscribe_spec.rb
@@ -566,5 +566,8 @@ end
 
 def stub_maptiler_geocoding(search:, response:)
   proxy.stub("https://api.maptiler.com:443/geocoding/#{CGI.escape_uri_component(search)}.json")
-    .and_return(json: response)
+    .and_return(
+      headers: {"Access-Control-Allow-Origin" => "*"},
+      json: response
+    )
 end

--- a/spec/features/visitors/subscribe_spec.rb
+++ b/spec/features/visitors/subscribe_spec.rb
@@ -354,9 +354,7 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
               find("li", text: "Central London").click
             end
 
-            within "#zone-tags" do
-              expect(page).to have_text("Central London")
-            end
+            find("h4", text: "London").click # to expand details tag
             expect(page).to have_checked_field("Central London")
           end
         end

--- a/spec/features/visitors/view_about_page_spec.rb
+++ b/spec/features/visitors/view_about_page_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.feature "About page" do
+  before do
+    forecasts = [
+      Fixtures::API.zone_forecast(day: :today),
+      Fixtures::API.zone_forecast(day: :tomorrow),
+      Fixtures::API.zone_forecast(day: :day_after_tomorrow)
+    ]
+    HttpStubs.stub_cerc_api_with(forecasts)
+  end
+
   describe "Visit the about page" do
     it "should display the about page" do
       visit "about"

--- a/spec/features/visitors/view_air_quality_alerts_spec.rb
+++ b/spec/features/visitors/view_air_quality_alerts_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Forecasts page - air quality alerts" do
     it "shows an air quality alert of moderate for tomorrow" do
       visit forecast_path
       tab_selector = ".tab[data-date='#{Date.tomorrow}']"
-      find(tab_selector).trigger("click")
+      find(tab_selector).click
 
       within(tab_selector) do
         expect_to_see_alert_level("Moderate")
@@ -56,7 +56,7 @@ RSpec.feature "Forecasts page - air quality alerts" do
     it "shows an air quality alert of very high for the day after tomorrow" do
       visit forecast_path
       tab_selector = ".tab[data-date='#{Date.tomorrow + 1.day}']"
-      find(tab_selector).trigger("click")
+      find(tab_selector).click
 
       within(tab_selector) do
         expect_to_see_alert_level("Very high")

--- a/spec/features/visitors/view_alerts_page_spec.rb
+++ b/spec/features/visitors/view_alerts_page_spec.rb
@@ -3,9 +3,18 @@
 RSpec.feature "Air quality alerts page" do
   describe "Visit the air quality alerts page" do
     context "when there are no alerts" do
+      before do
+        forecasts = [
+          Fixtures::API.zone_forecast(day: :today),
+          Fixtures::API.zone_forecast(day: :tomorrow),
+          Fixtures::API.zone_forecast(day: :day_after_tomorrow)
+        ]
+        HttpStubs.stub_cerc_api_with(forecasts)
+      end
+
       it "should display a message" do
         visit alerts_path
-        expect(page).to have_content "No alerts"
+        expect(page).to have_content "No air pollution alerts"
       end
     end
 

--- a/spec/features/visitors/view_forecasts_spec.rb
+++ b/spec/features/visitors/view_forecasts_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Forecasts page" do
         tab_selector_today = ".tab[data-date='#{Date.today}']"
         tab_selector_tomorrow = ".tab[data-date='#{Date.tomorrow}']"
         tab_selector_day_after_tomorrow = ".tab[data-date='#{Date.tomorrow + 1.day}']"
-        find(tab_selector_tomorrow).trigger("click")
+        find(tab_selector_tomorrow).click
 
         # See that the tomorrow tab is active
         expect(page).to have_css("#{tab_selector_tomorrow}.active")
@@ -126,7 +126,7 @@ RSpec.feature "Forecasts page" do
         ##
 
         visit forecast_path
-        find(tab_selector_day_after_tomorrow).trigger("click")
+        find(tab_selector_day_after_tomorrow).click
 
         # See that the day after tomorrow tab is active
         expect(page).to have_css("#{tab_selector_day_after_tomorrow}.active")

--- a/spec/features/visitors/view_health_advice_page_spec.rb
+++ b/spec/features/visitors/view_health_advice_page_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.feature "Health advice page" do
+  before do
+    forecasts = [
+      Fixtures::API.zone_forecast(day: :today),
+      Fixtures::API.zone_forecast(day: :tomorrow),
+      Fixtures::API.zone_forecast(day: :day_after_tomorrow)
+    ]
+    HttpStubs.stub_cerc_api_with(forecasts)
+  end
+
   describe "Visit the health advice page" do
     it "should display the health advice page" do
       visit "health_advice"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,7 +2,6 @@
 
 Dir[Rails.root.join("spec", "feature_steps", "**", "*.rb")].sort.each { |f| require f }
 
-require "capybara/cuprite"
 require "capybara/rspec"
 require "capybara-screenshot/rspec"
 require "billy/capybara/rspec"
@@ -10,25 +9,33 @@ require "billy/capybara/rspec"
 Capybara::Screenshot.prune_strategy = {keep: 20}
 Capybara.default_max_wait_time = 5
 Capybara.disable_animation = true
+Capybara.asset_host = "http://localhost:3000"
 
-Capybara.javascript_driver = :cuprite_proxy
-Capybara.register_driver(:cuprite_proxy) do |app|
-  browser_options = {}.tap do |opts|
-    opts["no-sandbox"] = nil if ENV["CI"]
-    opts["ignore-certificate-errors"] = nil
-  end
-  Capybara::Cuprite::Driver.new(
-    app,
-    window_size: [1200, 800],
-    js_errors: true,
-    timeout: 10,
-    process_timeout: 15,
-    inspector: ENV["INSPECTOR"],
-    # headless: false,
-    browser_options: browser_options
-  ).tap do |driver|
-    driver.set_proxy(Billy.proxy.host, Billy.proxy.port)
-  end
+def browser_options
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless=new")
+  options.add_argument("--enable-features=NetworkService,NetworkServiceInProcess")
+  options.add_argument("--ignore-certificate-errors")
+  options.add_argument("--proxy-server=#{Billy.proxy.host}:#{Billy.proxy.port}")
+  options.add_argument("--disable-gpu") if Gem.win_platform?
+  options.add_argument("--no-sandbox") if ENV["CI"]
+  options.add_argument("--log-level=3")
+  options.add_argument("--window-size=1200,2000")
+  options.add_argument("--disable-dev-shm-usage")
+  options
 end
 
-Capybara.asset_host = "http://localhost:3000"
+def driver(app)
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: browser_options,
+    clear_local_storage: true,
+    clear_session_storage: true
+  )
+end
+
+Capybara.register_driver :chrome do |app|
+  driver(app)
+end
+Capybara.javascript_driver = :chrome


### PR DESCRIPTION
## Context
We wanted to add automated accessibility testing to the app using Axe. Unfortunately the Axe gem does not work with Cuprite, the browser testing tool we're currently using. That means we need to replace it with Selenium.

## Changes in this PR
This PR replaces Cuprite with Selenium as our automated browser testing tool and makes a few tweaks to tests to reflect slightly different behaviour between the two tools.