### PR TITLE
Add automated accessibility tests with Axe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ group :development do
 end
 
 group :development, :test do
+  gem "axe-core-capybara" # Accessibility testing
+  gem "axe-core-rspec" # Accessibility testing
   gem "binding_of_caller"
   gem "brakeman"
   gem "bullet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,22 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    axe-core-api (4.10.2)
+      dumb_delegator
+      ostruct
+      virtus
+    axe-core-capybara (4.10.2)
+      axe-core-api (= 4.10.2)
+      dumb_delegator
+    axe-core-rspec (4.10.2)
+      axe-core-api (= 4.10.2)
+      dumb_delegator
+      ostruct
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     benchmark (0.4.0)
     better_errors (2.10.1)
@@ -113,6 +129,8 @@ GEM
       logger (~> 1.5)
     climate_control (1.2.0)
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.5)
     connection_pool (2.4.1)
     cookiejar (0.3.4)
@@ -128,10 +146,13 @@ GEM
       sass-embedded (~> 1.63)
     date (3.3.4)
     debug_inspector (1.2.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dotenv (3.1.7)
     drb (2.2.1)
+    dumb_delegator (1.1.0)
     em-http-request (1.1.7)
       addressable (>= 2.3.4)
       cookiejar (!= 0.3.1)
@@ -170,6 +191,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     io-console (0.7.2)
     irb (1.14.3)
       rdoc (>= 4.0.0)
@@ -228,6 +250,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
+    ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.7.0)
       ast (~> 2.4.1)
@@ -399,6 +422,7 @@ GEM
     terser (1.2.5)
       execjs (>= 0.3.0, < 3)
     thor (1.3.2)
+    thread_safe (0.3.6)
     timeout (0.4.1)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
@@ -412,6 +436,10 @@ GEM
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -441,6 +469,8 @@ PLATFORMS
 
 DEPENDENCIES
   active_link_to (~> 1.0)
+  axe-core-capybara
+  axe-core-rspec
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)

--- a/app/assets/stylesheets/text-block.scss
+++ b/app/assets/stylesheets/text-block.scss
@@ -136,7 +136,7 @@ details {
       background: var(--lightest-grey);
     }
 
-    button.show-button {
+    span.show-button {
       display: flex;
       align-items: center;
       gap: 0.5rem;
@@ -160,7 +160,7 @@ details {
     summary {
       background: var(--lightest-grey);
 
-      button.show-button {
+      span.show-button {
         &::before {
           transform: rotate(180deg);
         }
@@ -172,7 +172,7 @@ details {
     summary {
       position: relative;
 
-      button {
+      span.show-button {
         position: absolute;
         top: calc(50% - 0.75rem);
         right: 1rem;

--- a/app/javascript/controllers/application_controller.js
+++ b/app/javascript/controllers/application_controller.js
@@ -12,14 +12,12 @@ export default class ApplicationController extends Controller {
   addShowButtonToSummaryTags() {
     this.element.querySelectorAll("summary").forEach((summary) => {
       if (!summary.querySelector(".show-button")) {
-        const button = document.createElement("button");
+        const button = document.createElement("span");
         button.innerHTML = "Show";
         button.className = "show-button";
         button.tabIndex = -1;
-        button.onclick = (e) => {
-          e.preventDefault();
-          summary.parentElement.open = !summary.parentElement.open;
-          button.innerHTML = summary.parentElement.open ? "Hide" : "Show";
+        button.onclick = () => {
+          button.innerHTML = summary.parentElement.open ? "Show" : "Hide";
         };
         summary.appendChild(button);
       }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -177,6 +177,9 @@ export default class MapController extends Controller {
         this.updateForecastZone(e.feature?.geometry?.coordinates);
       })
       .addTo(this.map);
+
+    const searchButton = document.getElementsByClassName("search-button")[0];
+    searchButton.setAttribute("aria-label", "Search for a location");
   }
 
   addGeolocationControl() {
@@ -193,6 +196,7 @@ export default class MapController extends Controller {
     });
     this.map.addLayer(streetMap);
     streetMap.getCanvas().removeAttribute("tabindex");
+    streetMap.getCanvas().setAttribute("aria-label", "Street map layer");
   }
 
   addPlaceNamesLayer() {
@@ -203,6 +207,7 @@ export default class MapController extends Controller {
     });
     this.map.addLayer(placeNames);
     placeNames.getCanvas().removeAttribute("tabindex");
+    placeNames.getCanvas().setAttribute("aria-label", "Place names map layer");
   }
 
   addPollutionLayer() {

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -17,22 +17,22 @@
   <h2 class="mb-1">Partners</h2>
   <p>The airTEXT Consortium is a consortium of London Boroughs, Slough Borough Council, Chelmsford City Council, Colchester Borough Council, Maldon District Council, Elmbridge Borough Council, Mole Valley District Council, Reigate and Banstead Borough Council, Runnymede Borough Council, Spelthorne Borough Council, Tandridge District Council, the Greater London Authority, the Environment Agency and Public Health England.</p>
 
-  <h4>Islington Council</h4>
+  <h3>Islington Council</h3>
   <p><%= link_to('Islington Council', 'https://www.islington.gov.uk', target: '_blank') %> currently leads the airTEXT consortium.</p>
 
-  <h4>Cambridge: </h4>
+  <h3>Cambridge: </h3>
   <p>Additional forecasts are provided for Cambridge although the Council is not a member of the airTEXT consortium.</p>
 
-  <h4>CERC</h4>
+  <h3>CERC</h3>
   <p><%= link_to('CERC', 'https://www.cerc.co.uk', target: '_blank') %> develop and operate the airTEXT forecasting and alert system, which has operated across London since March 2007.</p>
 
-  <h4>European Commission</h4>
+  <h3>European Commission</h3>
   <p>CERC has been a partner in a number of EU-funded projects which have contributed to the development of airTEXT, including PASODOBLE and the series of MACC projects. CERC is a member of the team delivering the EU's <%= link_to('Copernicus Atmospheric Monitoring Service (CAMS)', 'https://atmosphere.copernicus.eu/', target: '_blank') %>%. CERC is part of the sub-team facilitating user interaction.</p>
 
-  <h4>DEFRA</h4>
+  <h3>DEFRA</h3>
   <p><%= link_to('Department for the Environment, Food and Rural Affairs', 'https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs', target: '_blank') %>% has provided support through air quality grants to member Councils. Grants to Islington and Hackney in 2012 funded the development of the daily bulletins for each Borough. A grant to Southwark and Lambeth Council in 2022 funded the re-development of the operational system using Cloud technology and the development of web APIs for integrating airTEXT data in other apps and services.</p>
 
-  <h4>European Space Agency</h4>
+  <h3>European Space Agency</h3>
   <p><%= link_to('ESA', 'https://www.esa.int', target: '_blank') %> supported the inital development of airTEXT through the <%= link_to('PROMOTE', 'https://www.esa.int/Our_Activities/Space_Engineering_Technology/Space_for_health/Air_quality_and_pollution', target: '_blank') %> projects.</p>
 
   <div class="mt-2">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer class="site-footer" role="contentinfo">
   <div class="footer-content">
-    <nav>
+    <nav aria-label="Footer navigation">
       <ul>
         <li><%= active_link_to "Air quality forecast", forecast_path %></li>
         <li><%= active_link_to "Air pollution alerts", alerts_path %></li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
       <button data-action="navigation#toggleMenu" data-navigation-target="menuButton">Menu</button>
     </div>
     <hr>
-    <nav>
+    <nav aria-label="Main navigation">
       <ul data-navigation-target="menuList">
         <li><%= active_link_to "Air quality forecast", forecast_path %></li>
         <li><%= active_link_to "Air pollution alerts", alerts_path %></li>

--- a/app/views/shared/_health_advice.html.erb
+++ b/app/views/shared/_health_advice.html.erb
@@ -1,4 +1,4 @@
 <div id="health-advice-block" class="block">
-  <h3 class="h3 mt-0 mb-2">Do you know how you can protect yourself and others in your community?</h3>
+  <h2 class="h3 mt-0 mb-2">Do you know how you can protect yourself and others in your community?</h2>
   <%= link_to "Learn more about health effects", health_advice_path, class: "a" %>
 </div>

--- a/app/views/subscriptions/confirmation.html.erb
+++ b/app/views/subscriptions/confirmation.html.erb
@@ -6,7 +6,7 @@
 
     <section class="mb-2">
       <header>
-        <h4>Channels</h4>
+        <h3>Channels</h3>
         <p><%= link_to "Edit", wizard_path(:contact_details) %></p>
       </header>
       <dl>
@@ -21,7 +21,7 @@
 
     <section class="mb-2">
       <header>
-        <h4>Alert areas</h4>
+        <h3>Alert areas</h3>
         <p><%= link_to "Edit", wizard_path(:zone_selection) %></p>
       </header>
       <ul class="list">
@@ -33,7 +33,7 @@
 
     <section class="mb-2">
       <header>
-        <h4>Selected time</h4>
+        <h3>Selected time</h3>
         <p><%= link_to "Edit", wizard_path(:time_selection) %></p>
       </header>
       <ul class="list">

--- a/app/views/subscriptions/email_verification.html.erb
+++ b/app/views/subscriptions/email_verification.html.erb
@@ -4,7 +4,7 @@
   <%= f.label :verification_code_email, "Verification code", class: "sr-only" %>
   <div class="mb-2 verification-code">
     <% 6.times do |i| %>
-      <%= f.text_field :verification_code_email, multiple: true, id: "#{f.object_name}_verification_code_email_#{i}", maxlength: 1, size: 1, value: nil, data: { action: "input->subscription#processVerificationCodeInput keydown->subscription#processVerificationCodeMove paste->subscription#processVerificationCodePaste" } %>
+      <%= f.text_field :verification_code_email, multiple: true, id: "#{f.object_name}_verification_code_email_#{i}", maxlength: 1, size: 1, value: nil, "aria-label": "Verification code digit #{i}", data: { action: "input->subscription#processVerificationCodeInput keydown->subscription#processVerificationCodeMove paste->subscription#processVerificationCodePaste" } %>
     <% end %>
   </div>
   <p>If the code does not arrive, please check your spam folder. You can also

--- a/app/views/subscriptions/sms_number_verification.html.erb
+++ b/app/views/subscriptions/sms_number_verification.html.erb
@@ -4,7 +4,7 @@
   <%= f.label :verification_code_sms_number, "Verification code", class: "sr-only" %>
   <div class="mb-2 verification-code">
     <% 6.times do |i| %>
-      <%= f.text_field :verification_code_sms_number, multiple: true, id: "#{f.object_name}_verification_code_sms_number_#{i}", maxlength: 1, size: 1, value: nil, data: { action: "input->subscription#processVerificationCodeInput keydown->subscription#processVerificationCodeMove paste->subscription#processVerificationCodePaste" } %>
+      <%= f.text_field :verification_code_sms_number, multiple: true, id: "#{f.object_name}_verification_code_sms_number_#{i}", maxlength: 1, size: 1, value: nil, "aria-label": "Verification code digit #{i}", data: { action: "input->subscription#processVerificationCodeInput keydown->subscription#processVerificationCodeMove paste->subscription#processVerificationCodePaste" } %>
     <% end %>
   </div>
   <p>If the code does not arrive, please check your spam folder. You can also

--- a/app/views/subscriptions/voice_number_verification.html.erb
+++ b/app/views/subscriptions/voice_number_verification.html.erb
@@ -4,7 +4,7 @@
   <%= f.label :verification_code_voice_number, "Verification code", class: "sr-only" %>
   <div class="mb-2 verification-code">
     <% 6.times do |i| %>
-      <%= f.text_field :verification_code_voice_number, multiple: true, id: "#{f.object_name}_verification_code_voice_number_#{i}", maxlength: 1, size: 1, value: nil, data: { action: "input->subscription#processVerificationCodeInput keydown->subscription#processVerificationCodeMove paste->subscription#processVerificationCodePaste" } %>
+      <%= f.text_field :verification_code_voice_number, multiple: true, id: "#{f.object_name}_verification_code_voice_number_#{i}", maxlength: 1, size: 1, value: nil, "aria-label": "Verification code digit #{i}", data: { action: "input->subscription#processVerificationCodeInput keydown->subscription#processVerificationCodeMove paste->subscription#processVerificationCodePaste" } %>
     <% end %>
   </div>
   <p>You can also 

--- a/spec/features/visitors/subscribe_spec.rb
+++ b/spec/features/visitors/subscribe_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Subscribing to alerts", type: :feature, js: true do
+RSpec.feature "Subscribing to alerts", js: true do
   let(:forecasts) do
     [
       Fixtures::API.zone_forecast(day: :today),
@@ -22,12 +22,21 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
       expect(page).to have_text("Air pollution alert service subscription")
       expect(page).to have_text("Choose the channels")
     end
+
+    it "is accessible" do
+      visit root_path
+      expect(page).to be_accessible
+    end
   end
 
   describe "Subscribing to alerts" do
     describe "Contact details" do
       before do
         visit subscriptions_path(id: :contact_details)
+      end
+
+      it "is accessible" do
+        expect(page).to be_accessible
       end
 
       it "shows the email field when I select the email option" do
@@ -97,6 +106,10 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
         before do
           fill_form_up_to(:contact_details_email)
           visit subscriptions_path(id: :email_verification)
+        end
+
+        it "is accessible" do
+          expect(page).to be_accessible
         end
 
         context "when I enter the correct verification code" do
@@ -176,6 +189,10 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
           visit subscriptions_path(id: :sms_number_verification)
         end
 
+        it "is accessible" do
+          expect(page).to be_accessible
+        end
+
         context "when I enter the correct verification code" do
           let(:code) { "123456" }
 
@@ -224,6 +241,10 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
         before do
           fill_form_up_to(:contact_details_voice)
           visit subscriptions_path(id: :voice_number_verification)
+        end
+
+        it "is accessible" do
+          expect(page).to be_accessible
         end
 
         context "when I enter the correct verification code" do
@@ -327,6 +348,10 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
           ],
           "attribution" => "<a href=\"https =>//www.maptiler.com/copyright/\" target=\"_blank\">&copy; MapTiler</a> <a href=\"https =>//www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>"
         }
+      end
+
+      it "is accessible" do
+        expect(page).to be_accessible
       end
 
       describe "Searching for zones" do
@@ -478,6 +503,10 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
         visit subscriptions_path(id: :time_selection)
       end
 
+      it "is accessible" do
+        expect(page).to be_accessible
+      end
+
       describe "Validating the form" do
         it "shows an error if I don't select a time" do
           click_on "Next"
@@ -498,6 +527,10 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
       before do
         fill_form_up_to(:time_selection)
         visit subscriptions_path(id: :wrap_up)
+      end
+
+      it "is accessible" do
+        expect(page).to be_accessible
       end
 
       describe "Validating the form" do
@@ -528,6 +561,10 @@ RSpec.feature "Subscribing to alerts", type: :feature, js: true do
         fill_form_up_to(:wrap_up)
         visit subscriptions_path(id: :confirmation)
         allow(CercSubscriberApiClient).to receive(:create_subscription).and_return(true)
+      end
+
+      it "is accessible" do
+        expect(page).to be_accessible
       end
 
       it "shows the confirmation page" do

--- a/spec/features/visitors/view_about_page_spec.rb
+++ b/spec/features/visitors/view_about_page_spec.rb
@@ -15,5 +15,10 @@ RSpec.feature "About page" do
       visit "about"
       expect(page).to have_content "About airTEXT"
     end
+
+    it "is accessible", js: true do
+      visit "about"
+      expect(page).to be_accessible
+    end
   end
 end

--- a/spec/features/visitors/view_alerts_page_spec.rb
+++ b/spec/features/visitors/view_alerts_page_spec.rb
@@ -16,6 +16,11 @@ RSpec.feature "Air quality alerts page" do
         visit alerts_path
         expect(page).to have_content "No air pollution alerts"
       end
+
+      it "is accessible", js: true do
+        visit alerts_path
+        expect(page).to be_accessible
+      end
     end
 
     context "when there are alerts" do
@@ -44,6 +49,11 @@ RSpec.feature "Air quality alerts page" do
         expect(page).to have_content "High"
         expect(page).to have_content "Moderate"
         expect(page).to have_content "Very high"
+      end
+
+      it "is accessible", js: true do
+        visit alerts_path
+        expect(page).to be_accessible
       end
     end
   end

--- a/spec/features/visitors/view_forecasts_spec.rb
+++ b/spec/features/visitors/view_forecasts_spec.rb
@@ -146,6 +146,11 @@ RSpec.feature "Forecasts page" do
         # Predicted temperature level for the day after tomorrow
         expect_prediction(category: :temperature, level: :high)
       end
+
+      it "is accessible", js: true do
+        visit forecast_path
+        expect(page).to be_accessible
+      end
     end
 
     describe "Viewing pollen prediction" do

--- a/spec/features/visitors/view_health_advice_page_spec.rb
+++ b/spec/features/visitors/view_health_advice_page_spec.rb
@@ -15,5 +15,10 @@ RSpec.feature "Health advice page" do
       visit "health_advice"
       expect(page).to have_content "Health advice"
     end
+
+    it "is accessible", js: true do
+      visit "health_advice"
+      expect(page).to be_accessible
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,9 @@ WebMock.disable_net_connect!(allow_localhost: true, allow: [
   "api.maptiler.com"
 ])
 
+require "axe-capybara" # Accessibility testing
+require "axe-rspec" # Accessibility testing
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/support/axe_helper.rb
+++ b/spec/support/axe_helper.rb
@@ -13,7 +13,7 @@ module AxeHelper
     end
 
     def check
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.skipping("color-contrast")
     end
   end
 end

--- a/spec/support/axe_helper.rb
+++ b/spec/support/axe_helper.rb
@@ -1,0 +1,19 @@
+module AxeHelper
+  RSpec::Matchers.define :be_accessible do
+    match do |page|
+      check
+    end
+
+    failure_message do |actual|
+      check
+    end
+
+    failure_message_when_negated do |actual|
+      check
+    end
+
+    def check
+      expect(page).to be_axe_clean
+    end
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -39,3 +39,7 @@ Capybara.register_driver :chrome do |app|
   driver(app)
 end
 Capybara.javascript_driver = :chrome
+
+# AxeCapybara.configure(:chrome) do |config|
+#   config.page = driver(nil) # I don't fully understand this line, but it works for DfE (https://github.com/DFE-Digital/npq-registration/blob/cc942c503f92fa7b04371b33196c5af0f0105505/spec/rails_helper.rb#L50)
+# end


### PR DESCRIPTION
## Context
We currently don't have any automated accessibility tests. [RFC 244](https://github.com/dxw/tech-team-rfcs/blob/main/ways-of-working/rfc-244-use-automated-accessibility-checks-in-feature-tests.md) requires that we implement this.

## Changes in this PR
This PR adds automated accessibility testing using Axe and corrects the accessibility errors it has identified.