### PR TITLE
Update design of alerts page

### DIFF
--- a/app/assets/stylesheets/air-quality-alerts-page.scss
+++ b/app/assets/stylesheets/air-quality-alerts-page.scss
@@ -14,9 +14,31 @@
     }
   }
 
+  .details-wrapper {
+    @media (max-width: variables.$mobile-breakpoint) {
+      margin: 0 -1rem;
+    }
+  }
+
+  details {
+    summary {
+      border-top: 1px solid var(--border-color);
+    }
+
+    &:last-child {
+      summary {
+        border-bottom: 1px solid var(--border-color);
+      }
+    }
+
+    &[open] {
+      margin-bottom: 1rem;
+    }
+  }
+
   .air-quality-alerts-table {
     @media (min-width: variables.$mobile-breakpoint) {
-      border: 1px solid var(--light-grey);
+      border: 1px solid var(--lightest-grey);
     }
 
     .cell {
@@ -26,10 +48,11 @@
     .table-header {
       display: grid;
       grid-template-columns: 1.5fr 1fr 1fr 1fr;
+      background-color: var(--main-colour-lightest);
 
       @media (max-width: variables.$mobile-breakpoint) {
         grid-template-columns: 1fr 1fr 1fr;
-        margin-top: 2rem;
+        margin-bottom: 1rem;
       }
 
       h2 {
@@ -62,7 +85,7 @@
           grid-template-columns: 1fr 1fr 1fr;
         }
 
-        &:nth-child(2n + 1) {
+        &:nth-child(2n) {
           @media (min-width: variables.$mobile-breakpoint) {
             background-color: var(--lightest-grey);
           }

--- a/app/assets/stylesheets/text-block.scss
+++ b/app/assets/stylesheets/text-block.scss
@@ -140,7 +140,6 @@ details {
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      text-decoration: underline;
 
       &::before {
         content: "";
@@ -153,6 +152,11 @@ details {
         background-repeat: no-repeat;
         background-position: center center;
       }
+
+      &::after {
+        content: "Show";
+        text-decoration: underline;
+      }
     }
   }
 
@@ -163,6 +167,10 @@ details {
       span.show-button {
         &::before {
           transform: rotate(180deg);
+        }
+
+        &::after {
+          content: "Hide";
         }
       }
     }

--- a/app/assets/stylesheets/text-block.scss
+++ b/app/assets/stylesheets/text-block.scss
@@ -140,6 +140,7 @@ details {
       display: flex;
       align-items: center;
       gap: 0.5rem;
+      margin-top: 0.5rem;
 
       &::before {
         content: "";
@@ -184,6 +185,7 @@ details {
         position: absolute;
         top: calc(50% - 0.75rem);
         right: 1rem;
+        margin-top: 0;
 
         &::after {
           display: none;

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -24,6 +24,20 @@ class ForecastsController < ApplicationController
     end
   end
 
+  def alerts
+    @alerts = {}
+    CercForecastService.latest_forecasts.each do |alert|
+      zone_group = alert.zone.zone_group.name
+      @alerts[zone_group] ||= []
+      @alerts[zone_group] << alert if alert.data.map { |f| f.air_quality_alert? }.count(true).positive?
+    end
+
+    # Sort the alerts by type
+    @alerts.each do |zone_group, alerts|
+      alerts.sort_by! { |alert| [-alert.zone.cerc_type, alert.zone.name] }
+    end
+  end
+
   def pollutant_forecasts
     load_options
     latest_forecasts = CercForecastService.latest_forecasts

--- a/app/javascript/controllers/application_controller.js
+++ b/app/javascript/controllers/application_controller.js
@@ -13,12 +13,9 @@ export default class ApplicationController extends Controller {
     this.element.querySelectorAll("summary").forEach((summary) => {
       if (!summary.querySelector(".show-button")) {
         const button = document.createElement("span");
-        button.innerHTML = "Show";
+        button.title = "Show more";
         button.className = "show-button";
         button.tabIndex = -1;
-        button.onclick = () => {
-          button.innerHTML = summary.parentElement.open ? "Show" : "Hide";
-        };
         summary.appendChild(button);
       }
     });

--- a/app/views/forecasts/_alert_guidance.html.erb
+++ b/app/views/forecasts/_alert_guidance.html.erb
@@ -1,7 +1,6 @@
 <turbo-frame id="alert-guidance-frame">
 <% if @day_forecast.air_quality_alert? %>
   <div class="alert-guidance text-block daqi-level-<%= @day_forecast.air_pollution[:label].parameterize %> p-2 mb-1">
-    <h3 class="mb-2">Action required</h3>
     <%= render(HealthGuidanceComponent.new(:air_pollution, @day_forecast.air_pollution[:label].parameterize(separator: "_").to_sym, classes: ["mb-2"])) %>
     <p><%= link_to("Learn more about the air pollution alert", alerts_path) %></p>
     <span class="forecast-timestamp">Forecast updated at <%= @day_forecast.air_pollution[:forecasted_at].strftime("%H:%M on %A %d %B %Y") %></span>

--- a/app/views/forecasts/_daqi_scale_guide.html.erb
+++ b/app/views/forecasts/_daqi_scale_guide.html.erb
@@ -1,4 +1,4 @@
-<article class="text-block p-3">
+<article class="text-block p-2">
   <h2 class="mb-2">Air pollution index and health advice</h2>
   <p>Adults and children with heart or lung problems are at greater risk of symptoms. Follow your doctor's usual advice about exercising and managing your condition.</p>
   <p>Anyone experiencing symptoms should follow the guidance provided below.</p>

--- a/app/views/forecasts/_how_forecasts_are_made.html.erb
+++ b/app/views/forecasts/_how_forecasts_are_made.html.erb
@@ -1,9 +1,9 @@
 <div id="how-forecasts-are-made" class="text-block">
   <details>
-    <summary class="p-3">
+    <summary class="p-2">
       <h3 class="mb-1">Learn how the forecasts are made</h3>
     </summary>
-    <div class="p-3">
+    <div class="p-2">
       <p>The air quality forecasts are produced using <%= link_to("CERC's air pollution forecasting system", 'https://www.cerc.co.uk/forecast', target: '_blank') %>. Information from weather forecasts, forecasts of pollution across Europe from the <%= link_to('CAMS', 'https://atmosphere.copernicus.eu/', target: '_blank') %> Regional Ensemble and very detailed data on about 30,000 pollution sources across London are fed into the world-leading <%= link_to('ADMS-Urban', 'https://www.cerc.co.uk/environmental-software/ADMS-Urban-model.html', target: '_blank') %> air quality model to produce forecasts of air quality at a high degree of spatial resolution (10m). These forecasts are issued twice a day at about 7am and 7pm. The forecasts are updated throughout the day using real-time monitoring data from LondonAir. We compare the forecasts with observed pollution levels to assess the accuracy of the forecasts. These performance statistics are available <%= link_to('here', './pdfs/airTEXT 2023 performance.pdf', target: '_blank') %>.</p>
       <p>The hourly concentrations of four pollutants are calculated: nitrogen dioxide (NO2), particulates (PM10 and PM2.5) and ozone (O3). From the hourly concentrations the daily air quality index (<%= link_to('DAQI', 'https://uk-air.defra.gov.uk/air-pollution/daqi', target: '_blank') %>) of each pollutant is derived. The overall air quality index is determined by the highest index for any of these pollutants.</p>
       <p>airTEXT issues an alert for a local authority or region if at least 10% of the geographical area is predicted to reach MODERATE or above.</p>

--- a/app/views/forecasts/alerts.html.erb
+++ b/app/views/forecasts/alerts.html.erb
@@ -1,66 +1,63 @@
 <% content_for :title, 'Air pollution alerts' %>
 
-<article class="text-block p-3">
-  <h1 class="mb-2">Air pollution alerts for Greater London and the South East</h1>
-  <p>The list below show all of the air pollution alerts fot the next three days.</p>
-  <p>If an area is not shown below, the air pollution is expected to be low for that region for all three days.</p>
-  <p>See the <%= link_to "health advice", health_advice_path %> page to learn more about how the expected pollution levels might affect your health.</p>
+<article class="p-3">
+  <div class="text-block mb-2">
+    <h1 class="mb-2">Air pollution alerts for Greater London and the South East</h1>
+    <p>The list below show all of the air pollution alerts fot the next three days.</p>
+    <p>If an area is not shown below, the air pollution is expected to be low for that region for all three days.</p>
+    <p>See the <%= link_to "health advice", health_advice_path %> page to learn more about how the expected pollution levels might affect your health.</p>
+  </div>
 
-  <%
-  @alerts = {level_1: [], level_2: []}
-  CercForecastService.latest_forecasts.each do |alert|
-    zone_level = "level_#{alert.zone.cerc_type}".to_sym
-    @alerts[zone_level] << alert if alert.data.map { |f| f.air_quality_alert? }.count(true).positive?
-  end
-  %>
+  <div class="details-wrapper">
+    <%  ZoneGroup.all.order(:order).each do |group| %>
+    <details class="zone-region-group">
+      <summary class="p-2">
+        <h2><%= group.name %></h4>
+        <%= content_tag :p, group.description, class: "mt-1" if group.description.present? %>
+      </summary>
+      <div class="air-quality-alerts-table">
+        <% if @alerts[group.name]&.any? %>
+        <div class="table-header">
+            <h3 class="cell">Today</h3>
+            <h3 class="cell"><%= (Date.today + 1.day).strftime("%A") %></h3>
+            <h3 class="cell"><%= (Date.today + 2.days).strftime("%A") %></h3>
+        </div>
+        <% end %>
 
-  <%
-    {
-      level_1: "grouped areas",
-      level_2: "individual areas",
-    }.each do |level, description|
-  %>
-  <div class="air-quality-alerts-table">
-    <div class="table-header">
-      <h2 class="h2 cell">Alerts raised per <%= description %></h2>
-
-      <% if @alerts[level].any? %>
-        <h3 class="cell">Today</h3>
-        <h3 class="cell"><%= (Date.today + 1.day).strftime("%A") %></h3>
-        <h3 class="cell"><%= (Date.today + 2.days).strftime("%A") %></h3>
-      <% end %>
-    </div>
-    <div class="table-body">
-      <% @alerts[level].each do |alert| %>
-        <div class="row">
-          <div class="zone-name cell">
-            <h4><%= alert.data.first.zone[:name] %></h4>
-            <%= link_to "Forecast", forecast_path(zone: alert.data.first.zone[:name], zoom: 10), class: "a" %>
-          </div>
-          <% alert.data.each do |forecast| %>
-            <div class="zone-day-alert cell">
-              <% if forecast.air_pollution[:label] == "LOW" %>
-                <span class="label">No alert</span>
-              <% else %>
-                <span class="label <%= "daqi-level-#{forecast.air_pollution[:total]}"%>"><%= forecast.air_pollution[:label].humanize %></span>
-                <span class="value">Index <%= forecast.air_pollution[:total] %>/10</span>
+        <div class="table-body">
+          <% @alerts[group.name]&.each do |alert| %>
+            <div class="row">
+              <div class="zone-name cell">
+                <h4><%= alert.data.first.zone[:name] %></h4>
+                <%= link_to "Forecast", forecast_path(zone: alert.data.first.zone[:name], zoom: 10), class: "a" %>
+              </div>
+              <% alert.data.each do |forecast| %>
+                <div class="zone-day-alert cell">
+                  <% if forecast.air_pollution[:label] == "LOW" %>
+                    <span class="label">No alert</span>
+                  <% else %>
+                    <span class="label <%= "daqi-level-#{forecast.air_pollution[:total]}"%>"><%= forecast.air_pollution[:label].humanize %></span>
+                    <span class="value">Index <%= forecast.air_pollution[:total] %>/10</span>
+                  <% end %>
+                </div>
               <% end %>
             </div>
           <% end %>
-        </div>
-      <% end %>
 
-      <% if @alerts[level].none? %>
-        <div class="no-alerts cell">
-          <span>No air pollution alerts are raised for any area within the next three days.</span>
+          <% unless @alerts[group.name].present? %>
+            <div class="no-alerts cell">
+              <span>No air pollution alerts are raised for any area within the next three days.</span>
+            </div>
+          <% end %>
         </div>
-      <% end %>
-    </div>
-    <div class="table-footer">
-      <span class="forecast-timestamp cell">Forecast updated at <%= CercForecastService.latest_forecast_date.strftime("%H:%M on %A %d %B %Y") %></span>
-    </div>
+
+        <div class="table-footer">
+          <span class="forecast-timestamp cell">Forecast updated at <%= CercForecastService.latest_forecast_date.strftime("%H:%M on %A %d %B %Y") %></span>
+        </div>
+      </div>
+    </details>
+    <% end %>
   </div>
-  <% end %>
 
   <div class="mt-2">
     <%= render "shared/back_to_top" %>

--- a/app/views/forecasts/alerts.html.erb
+++ b/app/views/forecasts/alerts.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'Air pollution alerts' %>
 
-<article class="p-3">
+<article class="p-2">
   <div class="text-block mb-2">
     <h1 class="mb-2">Air pollution alerts for Greater London and the South East</h1>
     <p>The list below show all of the air pollution alerts fot the next three days.</p>

--- a/app/views/forecasts/show.html.erb
+++ b/app/views/forecasts/show.html.erb
@@ -3,13 +3,13 @@
    <meta name="turbo-cache-control" content="no-cache">
 <% end %>
 
-<h1 class="h1 px-3 mt-3 mb-2">Air quality forecast</h1>
-<div id="intro" class="text-block px-3">
+<h1 class="h1 px-2 mt-3 mb-2">Air quality forecast</h1>
+<div id="intro" class="text-block px-2">
   <p>The air quality forecast displays levels of air pollution, ultraviolet (UV) rays, pollen, and temperature over the next three days for London, Surrey, Chelmsford, Maldon, Colchester and Cambridge.</p>
   <%= link_to("Sign up for air quality alerts", subscriptions_path, class: "button primary-cta") %>
 </div>
 
-<div id="forecast" data-controller="map forecast" class="px-3 mb-2">
+<div id="forecast" data-controller="map forecast" class="px-2 mb-2">
   <%= render "forecast_form" %>
   <%= render "forecast_tabs" %>
 
@@ -30,6 +30,6 @@
   <%= render "daqi_scale_guide" %>
 </div>
 
-<div class="mb-2 mx-3">
+<div class="mb-2 mx-2">
   <%= render "shared/back_to_top" %>
 </div>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'About' %>
 
-<article class="text-block p-3">
+<article class="text-block p-2">
   <h1 class="mb-2">About airTEXT</h1>
 
   <h2 class="mb-1">What is airTEXT?</h2>

--- a/app/views/pages/health_advice.html.erb
+++ b/app/views/pages/health_advice.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'Health advice' %>
 
-<article class="p-3">
+<article class="p-2">
   <div class="text-block">
     <h1 class="mb-2">Health advice</h1>
 
@@ -10,10 +10,10 @@
   </div>
 
   <details>
-    <summary class="p-3">
+    <summary class="p-2">
       <h2 class="mb-1">Air pollution index and advice</h2>
     </summary>
-    <div class="text-block p-3">
+    <div class="text-block p-2">
       <p>The index used to describe air quality is the <%= link_to('daily air quality index (DAQI)', 'http://uk-air.defra.gov.uk/air-pollution/daqi') %> for the UK. It represents air pollution using a 1 to 10 scale divided into four bands: low, moderate, high, and very high.</p>
 
       <h2>Air pollution advice</h2>
@@ -69,19 +69,19 @@
   </details>
 
   <details>
-    <summary class="p-3">
+    <summary class="p-2">
       <h2 class="mb-1">Long-term effects of air pollution</h2>
     </summary>
-    <div class="text-block p-3">
+    <div class="text-block p-2">
       <p>Information on the long-term health effects of air pollution is available in the 2009 Committee on the Medical Effects of Air Pollutants COMEAP report <%= link_to('Long-Term Exposure to Air Pollution: Effect on Mortality', 'http://www.hpa.org.uk/webc/HPAwebFile/HPAweb_C/1317137020526') %>.</p>
     </div>
   </details>
 
   <details>
-    <summary class="p-3">
+    <summary class="p-2">
       <h2 class="mb-1">Pollen advice</h2>
     </summary>
-    <div class="text-block p-3">
+    <div class="text-block p-2">
       <p>Pollen forecasts are predictors of daily grass pollen. Between late March and September, pollen count is at its highest, potentiated by a warm, humid, and windy atmosphere.</p>
 
       <div class="scale-guide">
@@ -119,10 +119,10 @@
   </details>
 
   <details>
-    <summary class="p-3">
+    <summary class="p-2">
       <h2 class="mb-1">Extreme weather advice</h2>
     </summary>
-    <div class="text-block p-3">
+    <div class="text-block p-2">
       <p>The forecasts show the minimum and maximum hourly temperatures predicted over a 24-hour period.</p>
 
       <div class="scale-guide">
@@ -146,10 +146,10 @@
   </details>
 
   <details>
-    <summary class="p-3">
+    <summary class="p-2">
       <h2 class="mb-1">Ultraviolet (UV) rays advice</h2>
     </summary>
-    <div class="text-block p-3">
+    <div class="text-block p-2">
       <p>The UV forecasts predict the maximum hourly cloud-adjusted solar UV index over 24 hours. The higher the UV index number, the less time it takes for the sun to damage your skin.</p>
 
       <div class="scale-guide">

--- a/app/views/subscriptions/_form_step.html.erb
+++ b/app/views/subscriptions/_form_step.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Air pollution alert service' %>
 
 <div class="intro mb-2">
-  <div class="text-block p-3">
+  <div class="text-block p-2">
     <h1 class="mb-2">Air pollution alert service subscription</h1>
     <p>Receive alerts by email, text, or voicemail when pollution levels are forecasted to be moderate, high, or very high.</p>
     <p>You can select up to five areas to receive alerts for, and you can unsubscribe from the service at any time.</p>
@@ -12,10 +12,10 @@
   </aside>
 </div>
 
-<hr class="mx-3">
+<hr class="mx-2">
 
 <turbo-frame id="form-frame" data-controller="subscription">
-  <div class="form-content p-3">
+  <div class="form-content p-2">
     <div class="progress-bar my-2">
       <% 4.times do |i| %>
         <span class="<%= i <= @step_group ? "completed" : "" %>"></span>

--- a/app/views/subscriptions/zone_selection.html.erb
+++ b/app/views/subscriptions/zone_selection.html.erb
@@ -27,7 +27,7 @@
         <details class="zone-region-group details-compact">
           <summary class="p-2">
             <h4><%= group.name %></h4>
-            <%= content_tag :p, group.description, class: "italic" if group.description.present? %>
+            <%= content_tag :p, group.description, class: "mt-1" if group.description.present? %>
           </summary>
           <div class="zone-checkboxes p-2">
             <% group.zones.order(cerc_type: :desc, name: :asc).group_by(&:cerc_type).each do |level, zones| %>


### PR DESCRIPTION
## Context
The design team have updated the design of the alerts page.

Trello: https://trello.com/c/2uRiT28U/160-update-alerts-page-design

## Changes in this PR
This PR updates the design of the alerts page to match the Figma design. The main change is that the fields are now grouped by region rather than by type.

There are also a couple of other minor UI fixes.

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/39bf97f4-296e-4d94-96fb-dca5eeae2971)


### After
![image](https://github.com/user-attachments/assets/929a1083-dcc0-4d20-a3d3-263a60aef34a)