### PR TITLE
Fix dummy forecast zone

### DIFF
--- a/app/services/cerc_forecast_service.rb
+++ b/app/services/cerc_forecast_service.rb
@@ -49,7 +49,7 @@ class CercForecastService
       }
 
       set_number = (ENV.fetch("DUMMY_FORECAST").presence || 1).to_i
-      [FactoryBot.build(:cached_forecast, data: forecast_sets[set_number])]
+      [FactoryBot.build(:cached_forecast, data: forecast_sets[set_number], zone: central_london)]
     end
 
     def zone_forecasts(zone, obtained_at: Time.current)


### PR DESCRIPTION
## Context
When users view alerts with dummy data, an error is thrown. This is because the zone isn't explicitly set on the cached forecast.

Rollbar: https://app.rollbar.com/a/dxw/fix/item/southwark-air-text/14

## Changes in this PR
This PR fixes the issue by setting the zone on the dummy cached forecast.