### PR TITLE
Fix checkbox state being set when not needed

### DIFF
--- a/app/javascript/controllers/subscription_controller.js
+++ b/app/javascript/controllers/subscription_controller.js
@@ -169,8 +169,10 @@ export default class SubscriptionController extends Controller {
 
   setCheckboxState(zone_name, state) {
     const checkbox = document.querySelector(`input[value="${zone_name}"]`);
-    checkbox.checked = state;
-    checkbox.dispatchEvent(new Event("change"));
+    if (checkbox.checked !== state) {
+      checkbox.checked = state;
+      checkbox.dispatchEvent(new Event("change"));
+    }
   }
 
   tag(zoneName) {


### PR DESCRIPTION
## Context
When the user checks a zone checkbox, we add the selected zone to the list of selected zones. This process also triggers the `setCheckboxState` which triggers another unnecessary change of state, which in some cases ended up reverting the user's action.

## Changes in this PR
This PR adds an extra check to make sure that we don't change the state of the checkbox unnecessarily.
