### PR TITLE
Fix build failure on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:css": "bundle exec rails dartsass:build",
     "build:css:watch": "bundle exec rails dartsass:watch",
     "dev": "yarn run build:css:watch && yarn run build:js:watch && yarn run serve",
-    "serve": "bundle exec rails server"
+    "serve": "bundle exec rails server",
+    "heroku-postbuild": "yarn run build:js"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",


### PR DESCRIPTION
## Context

#354 made a change to the build script that breaks Heroku deployment because it tries to run a Ruby command (to build CSS) before the Ruby buildpack has initialised.

## Changes in this PR
We fix this by adding a Heroku-specific build script which does not run that command. In production the CSS gets built automatically by Rails, so omitting the command isn't a problem.