### PR TITLE
Fix health advice icons

### DIFF
--- a/app/assets/guidance/health_guidance.json
+++ b/app/assets/guidance/health_guidance.json
@@ -118,7 +118,7 @@
       {
         "guidance": [
           {
-            "icons": ["indoors"],
+            "icons": ["stay-inside"],
             "html": "<strong>Those with hay fever or allergies</strong> should stay indoors to reduce exposure to pollen."
           },
           {
@@ -132,7 +132,7 @@
       {
         "guidance": [
           {
-            "icons": ["indoors"],
+            "icons": ["stay-inside"],
             "html": "<strong>Those with hay fever or allergies</strong> should stay indoors to reduce exposure to pollen."
           },
           {

--- a/app/views/pages/health_advice.html.erb
+++ b/app/views/pages/health_advice.html.erb
@@ -23,11 +23,9 @@
         <p>To reduce your exposure to air pollution, the bands have advice for everyone, plus for at-risk individuals including adults and children with heart or lung conditions, and older people.</p>
         <p>Sign up to receive free airTEXT alerts when there is a moderate, high or very high alert, and follow the health guidance.</p>
 
-<div>
         <h2>At-risk individuals</h2>
         <p>Follow your doctor's advice about exercising and managing your condition.</p>
         <p>Susceptible individuals may experience health effects even on low air pollution days. Anyone having symptoms should follow the guidance provided.</p>
-</div>
 
         <div class="scale-guide">
           <div class="headings mt-2">


### PR DESCRIPTION
## Context
Loading the health advice page in production caused a crash (see Rollbar issue 16). This was because the name of one of the icons had changed, but not been updated in the health advice code.

## Changes in this PR
This PR fixes the name of the icon to resolve the issue.
